### PR TITLE
Huff edits

### DIFF
--- a/docs/acros.tex
+++ b/docs/acros.tex
@@ -1,0 +1,172 @@
+\newacronym[longplural={metric tons of heavy metal}]{MTHM}{MTHM}{metric ton of heavy metal}
+\newacronym{ABM}{ABM}{agent-based modeling}
+\newacronym{ACDIS}{ACDIS}{Program in Arms Control \& Domestic and International Security}
+\newacronym{AHTR}{AHTR}{Advanced High Temperature Reactor}
+\newacronym{ANDRA}{ANDRA}{Agence Nationale pour la gestion des D\'echets RAdioactifs, the French National Agency for Radioactive Waste Management}
+\newacronym{ANL}{ANL}{Argonne National Laboratory}
+\newacronym{API}{API}{application programming interface}
+\newacronym{ARCH}{ARCH}{autoregressive conditional heteroskedastic}
+\newacronym{ARE}{ARE}{Aircraft Reactor Experiment}
+\newacronym{ARFC}{ARFC}{Advanced Reactors and Fuel Cycles}
+\newacronym{ARMA}{ARMA}{autoregressive moving average}
+\newacronym{ASME}{ASME}{American Society of Mechanical Engineers}
+\newacronym{ATWS}{ATWS}{Anticipated Transient Without Scram}
+\newacronym{BDBE}{BDBE}{Beyond Design Basis Event}
+\newacronym{BIDS}{BIDS}{Berkeley Institute for Data Science}
+\newacronym{BOL}{BOL}{Beginning-of-Life}
+\newacronym{BSD}{BSD}{Berkeley Software Distribution}
+\newacronym{CAFCA}{CAFCA}{ Code for Advanced Fuel Cycles Assessment }
+\newacronym{CASL}{CASL}{Consortium for Advanced Simulation of Light Water Reactors}
+\newacronym{CDTN}{CDTN}{Centro de Desenvolvimento da Tecnologia Nuclear}
+\newacronym{CEA}{CEA}{Commissariat \`a l'\'Energie Atomique et aux \'Energies Alternatives}
+\newacronym{CI}{CI}{continuous integration}
+\newacronym{CNEC}{CNEC}{Consortium for Nonproliferation Enabling Capabilities}
+\newacronym{CNEN}{CNEN}{Comiss\~{a}o Nacional de Energia Nuclear}
+\newacronym{CNERG}{CNERG}{Computational Nuclear Engineering Research Group}
+\newacronym{COSI}{COSI}{Commelini-Sicard}
+\newacronym{COTS}{COTS}{commercial, off-the-shelf}
+\newacronym{CSNF}{CSNF}{commercial spent nuclear fuel}
+\newacronym{CTAH}{CTAHs}{Coiled Tube Air Heaters}
+\newacronym{CUBIT}{CUBIT}{CUBIT Geometry and Mesh Generation Toolkit}
+\newacronym{CURIE}{CURIE}{Centralized Used Fuel Resource for Information Exchange}
+\newacronym{DAG}{DAG}{directed acyclic graph}
+\newacronym{DANESS}{DANESS}{Dynamic Analysis of Nuclear Energy System Strategies}
+\newacronym{DBE}{DBE}{Design Basis Event}
+\newacronym{DESAE}{DESAE}{Dynamic Analysis of Nuclear Energy Systems Strategies}
+\newacronym{DHS}{DHS}{Department of Homeland Security}
+\newacronym{DOE}{DOE}{Department of Energy}
+\newacronym{DRACS}{DRACS}{Direct Reactor Auxiliary Cooling System}
+\newacronym{DRE}{DRE}{dynamic resource exchange}
+\newacronym{DSNF}{DSNF}{DOE spent nuclear fuel}
+\newacronym{DYMOND}{DYMOND}{Dynamic Model of Nuclear Development }
+\newacronym{EBS}{EBS}{Engineered Barrier System}
+\newacronym{EDZ}{EDZ}{Excavation Disturbed Zone}
+\newacronym{EIA}{EIA}{U.S. Energy Information Administration}
+\newacronym{EPA}{EPA}{Environmental Protection Agency}
+\newacronym{EP}{EP}{Engineering Physics}
+\newacronym{FCO}{FCO}{Fuel Cycle Options}
+\newacronym{FCT}{FCT}{Fuel Cycle Technology}
+\newacronym{FCWMD}{FCWMD}{Fuel Cycle and Waste Management Division}
+\newacronym{FEHM}{FEHM}{Finite Element Heat and Mass Transfer}
+\newacronym{FEPs}{FEPs}{Features, Events, and Processes}
+\newacronym{FHR}{FHR}{Fluoride-Salt-Cooled High-Temperature Reactor}
+\newacronym{FLiBe}{FLiBe}{Fluoride-Lithium-Beryllium}
+\newacronym{GCAM}{GCAM}{Global Change Assessment Model}
+\newacronym{GDSE}{GDSE}{Generic Disposal System Environment}
+\newacronym{GDSM}{GDSM}{Generic Disposal System Model}
+\newacronym{GENIUSv1}{GENIUSv1}{Global Evaluation of Nuclear Infrastructure Utilization Scenarios, Version 1}
+\newacronym{GENIUSv2}{GENIUSv2}{Global Evaluation of Nuclear Infrastructure Utilization Scenarios, Version 2}
+\newacronym{GENIUS}{GENIUS}{Global Evaluation of Nuclear Infrastructure Utilization Scenarios}
+\newacronym{GPAM}{GPAM}{Generic Performance Assessment Model}
+\newacronym{GRSAC}{GRSAC}{Graphite Reactor Severe Accident Code}
+\newacronym{GUI}{GUI}{graphical user interface}
+\newacronym{HLW}{HLW}{high level waste}
+\newacronym{HPC}{HPC}{high-performance computing}
+\newacronym{HTC}{HTC}{high-throughput computing}
+\newacronym{HTGR}{HTGR}{High Temperature Gas-Cooled Reactor}
+\newacronym{IAEA}{IAEA}{International Atomic Energy Agency}
+\newacronym{IEMA}{IEMA}{Illinois Emergency Mangament Agency}
+\newacronym{INL}{INL}{Idaho National Laboratory}
+\newacronym{IPRR1}{IRP-R1}{Instituto de Pesquisas Radioativas Reator 1}
+\newacronym{IRP}{IRP}{Integrated Research Project}
+\newacronym{ISFSI}{ISFSI}{Independent Spent Fuel Storage Installation}
+\newacronym{ISRG}{ISRG}{Independent Student Research Group}
+\newacronym{JFNK}{JFNK}{Jacobian-Free Newton Krylov}
+\newacronym{LANL}{LANL}{Los Alamos National Laboratory}
+\newacronym{LBNL}{LBNL}{Lawrence Berkeley National Laboratory}
+\newacronym{LCOE}{LCOE}{levelized cost of electricity}
+\newacronym{LDRD}{LDRD}{laboratory directed research and development}
+\newacronym{LFR}{LFR}{Lead-Cooled Fast Reactor}
+\newacronym{LGPL}{LGPL}{Lesser GNU Public License}
+\newacronym{LLNL}{LLNL}{Lawrence Livermore National Laboratory}
+\newacronym{LMFBR}{LMFBR}{Liquid-Metal-cooled Fast Breeder Reactor}
+\newacronym{LOFC}{LOFC}{Loss of Forced Cooling}
+\newacronym{LOHS}{LOHS}{Loss of Heat Sink}
+\newacronym{LOLA}{LOLA}{Loss of Large Area}
+\newacronym{LP}{LP}{linear program}
+\newacronym{LWR}{LWR}{Light Water Reactor}
+\newacronym{MARKAL}{MARKAL}{MARKet and ALlocation}
+\newacronym{MA}{MA}{minor actinide}
+\newacronym{MCNP}{MCNP}{Monte Carlo N-Particle code}
+\newacronym{MILP}{MILP}{mixed-integer linear program}
+\newacronym{MIT}{MIT}{the Massachusetts Institute of Technology}
+\newacronym{MOAB}{MOAB}{Mesh-Oriented datABase}
+\newacronym{MOOSE}{MOOSE}{Multiphysics Object-Oriented Simulation Environment}
+\newacronym{MOX}{MOX}{mixed oxide}
+\newacronym{MSBR}{MSBR}{Molten Salt Breeder Reactor}
+\newacronym{MSRE}{MSRE}{Molten Salt Reactor Experiment}
+\newacronym{MSR}{MSR}{Molten Salt Reactor}
+\newacronym{NAGRA}{NAGRA}{National Cooperative for the Disposal of Radioactive Waste}
+\newacronym{NCSA}{NCSA}{National Center for Supercomputing Applications}
+\newacronym{NEAMS}{NEAMS}{Nuclear Engineering Advanced Modeling and Simulation}
+\newacronym{NEUP}{NEUP}{Nuclear Energy University Programs}
+\newacronym{NFCSim}{NFCSim}{Nuclear Fuel Cycle Simulator}
+\newacronym{NFC}{NFC}{Nuclear Fuel Cycle}
+\newacronym{NGNP}{NGNP}{Next Generation Nuclear Plant}
+\newacronym{NMWPC}{NMWPC}{Nuclear MW Per Capita}
+\newacronym{NNSA}{NNSA}{National Nuclear Security Administration}
+\newacronym{NPRE}{NPRE}{Department of Nuclear, Plasma, and Radiological Engineering}
+\newacronym{NQA1}{NQA-1}{Nuclear Quality Assurance - 1}
+\newacronym{NRC}{NRC}{Nuclear Regulatory Commission}
+\newacronym{NSF}{NSF}{National Science Foundation}
+\newacronym{NSSC}{NSSC}{Nuclear Science and Security Consortium}
+\newacronym{NUWASTE}{NUWASTE}{Nuclear Waste Assessment System for Technical Evaluation}
+\newacronym{NWF}{NWF}{Nuclear Waste Fund}
+\newacronym{NWTRB}{NWTRB}{Nuclear Waste Technical Review Board}
+\newacronym{OCRWM}{OCRWM}{Office of Civilian Radioactive Waste Management}
+\newacronym{ORION}{ORION}{ORION}
+\newacronym{ORNL}{ORNL}{Oak Ridge National Laboratory}
+\newacronym{PARCS}{PARCS}{Purdue Advanced Reactor Core Simulator}
+\newacronym{PBAHTR}{PB-AHTR}{Pebble Bed Advanced High Temperature Reactor}
+\newacronym{PBFHR}{PB-FHR}{Pebble-Bed Fluoride-Salt-Cooled High-Temperature Reactor}
+\newacronym{PEI}{PEI}{Peak Environmental Impact}
+\newacronym{PH}{PRONGHORN}{PRONGHORN}
+\newacronym{PI}{PI}{Principal Investigator}
+\newacronym{PNNL}{PNNL}{Pacific Northwest National Laboratory}
+\newacronym{PRIS}{PRIS}{Power Reactor Information System}
+\newacronym{PRKE}{PRKE}{Point Reactor Kinetics Equations}
+\newacronym{PSPG}{PSPG}{Pressure-Stabilizing/Petrov-Galerkin}
+\newacronym{PWAR}{PWAR}{Pratt and Whitney Aircraft Reactor}
+\newacronym{PWR}{PWR}{Pressurized Water Reactor}
+\newacronym{PyNE}{PyNE}{Python toolkit for Nuclear Engineering}
+\newacronym{PyRK}{PyRK}{Python for Reactor Kinetics}
+\newacronym{QA}{QA}{quality assurance}
+\newacronym{RDD}{RD\&D}{Research Development and Demonstration}
+\newacronym{RD}{R\&D}{Research and Development}
+\newacronym{RELAP}{RELAP}{Reactor Excursion and Leak Analysis Program}
+\newacronym{RIA}{RIA}{Reactivity Insertion Accident}
+\newacronym{RIF}{RIF}{Region-Institution-Facility}
+\newacronym{SAM}{SAM}{Simulation and Modeling}
+\newacronym{SCF}{SCF}{Software Carpentry Foundation}
+\newacronym{SFR}{SFR}{Sodium-Cooled Fast Reactor}
+\newacronym{SINDAG}{SINDA{\textbackslash}G}{Systems Improved Numerical Differencing Analyzer $\backslash$ Gaski}
+\newacronym{SKB}{SKB}{Svensk K\"{a}rnbr\"{a}nslehantering AB}
+\newacronym{SNF}{SNF}{spent nuclear fuel}
+\newacronym{SNL}{SNL}{Sandia National Laboratory}
+\newacronym{SNM}{SNM}{Special Nuclear Material}
+\newacronym{STC}{STC}{specific temperature change}
+\newacronym{SUPG}{SUPG}{Streamline-Upwind/Petrov-Galerkin}
+\newacronym{SWF}{SWF}{Separations and Waste Forms}
+\newacronym{SWU}{SWU}{Separative Work Unit}
+\newacronym{SandO}{S\&O}{Signatures and Observables}
+\newacronym{THW}{THW}{The Hacker Within}
+\newacronym{TRIGA}{TRIGA}{Training Research Isotope General Atomic}
+\newacronym{TRISO}{TRISO}{Tristructural Isotropic}
+\newacronym{TSM}{TSM}{Total System Model}
+\newacronym{TSPA}{TSPA}{Total System Performance Assessment for the Yucca Mountain License Application}
+\newacronym{UDB}{UDB}{Unified Database}
+\newacronym{UFD}{UFD}{Used Fuel Disposition}
+\newacronym{UML}{UML}{Unified Modeling Language}
+\newacronym{UNFSTANDARDS}{UNFST\&DARDS}{Used Nuclear Fuel Storage, Transportation \& Disposal Analysis Resource and Data System}
+\newacronym{UOX}{UOX}{uranium oxide}
+\newacronym{UQ}{UQ}{uncertainty quantification}
+\newacronym{US}{US}{United States}
+\newacronym{UW}{UW}{University of Wisconsin}
+\newacronym{VISION}{VISION}{the Verifiable Fuel Cycle Simulation Model}
+\newacronym{VV}{V\&V}{verification and validation}
+\newacronym{WIPP}{WIPP}{Waste Isolation Pilot Plant}
+\newacronym{YMG}{YMG}{Young Members Group}
+\newacronym{YMR}{YMR}{Yucca Mountain Repository Site}
+\newacronym{NEI}{NEI}{Nuclear Energy Institute}
+%\newacronym{<++>}{<++>}{<++>}
+%\newacronym{<++>}{<++>}{<++>}

--- a/docs/bibliography.bib
+++ b/docs/bibliography.bib
@@ -1,80 +1,4 @@
 
-@article{wigeland_separations_2006,
-	title = {Separations and {Transmutation} {Criteria} to {Improve} {Utilization} of a {Geologic} {Repository}},
-	volume = {154},
-	journal = {Nuclear Technology},
-	author = {Wigeland, Roald A. and Bauer, Theodore H. and Fanning, Thomas H. and Morris, Edgar E.},
-	month = apr,
-	year = {2006},
-	keywords = {Geologic Repository, Spent-Fuel Processing, Thermal Limits},
-	pages = {95--106},
-	file = {NT-Wigeland-Repository-Benefit.pdf:/Users/gwenchee/Zotero/storage/HI3B9NS8/NT-Wigeland-Repository-Benefit.pdf:application/pdf}
-}
-
-@techreport{doe_strategy_2013,
-	address = {Washington D.C., United States},
-	title = {Strategy for the {Management} and {Disposal} of {Used} {Nuclear} {Fuel} and {High}-{Level} {Radioactive} {Waste}},
-	url = {http://energy.gov/downloads/strategy-management-and-disposal-used-nuclear-fuel-and-high-level-radioactive-waste},
-	urldate = {2013-02-01},
-	institution = {United States Department of Energy},
-	author = {{DOE}},
-	month = jan,
-	year = {2013},
-	file = {2013 1-15 Nuclear_Waste_Report.pdf:/Users/gwenchee/Zotero/storage/P93IDV6R/2013 1-15 Nuclear_Waste_Report.pdf:application/pdf;doe_strategy_2013.pdf:/Users/gwenchee/Zotero/storage/GITPI2GM/doe_strategy_2013.pdf:application/pdf;Snapshot:/Users/gwenchee/Zotero/storage/RBC8D4NG/strategy-management-and-disposal-used-nuclear-fuel-and-high-level-radioactive-waste.html:text/html}
-}
-
-@techreport{wilson_adoption_2009,
-	title = {The {Adoption} of {Advanced} {Fuel} {Cycle} {Technology} {Under} a {Single} {Repository} {Policy}},
-	institution = {University of Wisconsin -- Madison},
-	author = {Wilson, P.},
-	year = {2009}
-}
-
-@article{carlsen_cyclus_2014,
-	title = {Cyclus v1.0.0},
-	url = {http://figshare.com/articles/Cyclus_v1_0_0/1041745},
-	doi = {http://dx.doi.org/10.6084/m9.figshare.1041745},
-	abstract = {Cyclus is the next-generation agent-based nuclear fuel cycle simulator, providing flexibility to users and developers through adynamic resource exchange solver and plug-in, user-developed agent framework.
-The goal of Cyclus is to enable a broad spectrum of fuel cycle simulation while providing a low barrier to entry for new users and agent developers. Cyclus engages with potential module developers and encourages them to join a vibrant community in anexpanding ecosystem. Users and developers are always welcome and encouraged to use or contribute to the Cyclus project.},
-	urldate = {2014-06-24},
-	journal = {Figshare},
-	author = {Carlsen, Robert W. and Gidden, Matthew and Huff, Kathryn and Opotowsky, Arrielle C. and Rakhimov, Olzhas and Scopatz, Anthony M. and Welch, Zach and Wilson, Paul},
-	month = jun,
-	year = {2014},
-	note = {http://dx.doi.org/10.6084/m9.figshare.1041745},
-	keywords = {Nuclear fuel cycle, agent-based simulation},
-	file = {cyclus_1.0.0:/Users/gwenchee/Zotero/storage/BDXXRM7B/Carlsen et al. - 2014 - Cyclus v1.0.0.zip:application/zip;cyclus_1.0.0:/Users/gwenchee/Zotero/storage/HW2QA8MN/Carlsen et al. - 2014 - Cyclus v1.0.0.zip:application/zip;Figshare Download:/Users/gwenchee/Zotero/storage/NN545PPD/Carlsen et al. - 2014 - Cyclus v1.0.0.zip:application/zip;Figshare Download:/Users/gwenchee/Zotero/storage/5MZCI93N/Carlsen et al. - 2014 - Cyclus v1.0.0.zip:application/zip;Figshare Snapshot:/Users/gwenchee/Zotero/storage/T982H6ZW/1041745.html:text/html;Figshare Snapshot:/Users/gwenchee/Zotero/storage/SEA6MHKH/1041745.html:text/html;Full Text (HTML):/Users/gwenchee/Zotero/storage/QSIAAMM8/1041745.html:text/html;Full Text (HTML):/Users/gwenchee/Zotero/storage/H2K87S9S/1041745.html:text/html}
-}
-
-@article{carlsen_cycamore_2014,
-	title = {Cycamore v1.0.0},
-	url = {http://figshare.com/articles/Cycamore_v1_0_0/1041829},
-	doi = {http://figshare.com/articles/Cycamore_v1_0_0/1041829},
-	abstract = {Additional module for Cyclus, the nuclear fuel cycle simulator developed at the University of Wisconsin - Madison, supporting the modeling of innovative fuel cycles.},
-	urldate = {2014-06-03},
-	journal = {Figshare},
-	author = {Carlsen, Robert W. and Gidden, Matthew and Huff, Kathryn and Opotowsky, Arrielle C. and Rakhimov, Olzhas and Scopatz, Anthony M. and Wilson, Paul},
-	month = jun,
-	year = {2014},
-	note = {http://figshare.com/articles/Cycamore\_v1\_0\_0/1041829},
-	keywords = {agent-based simulation, Nuclear Fuel Cycle},
-	file = {cycamore_1.0.0:/Users/gwenchee/Zotero/storage/W2VGZTDV/Scopatz et al. - 2014 - Cycamore v1.0.0:application/zip;Figshare Download:/Users/gwenchee/Zotero/storage/WQD2B5KA/Scopatz et al. - 2014 - Cycamore v1.0.0:application/zip;Figshare Snapshot:/Users/gwenchee/Zotero/storage/N44XFGRX/Scopatz et al. - 2014 - Cycamore v1.0.0.html:text/html;Full Text (HTML):/Users/gwenchee/Zotero/storage/H56U7DUZ/Scopatz et al. - 2014 - Cycamore v1.0.0.html:text/html}
-}
-
-@techreport{bell_origen_1973,
-	title = {{ORIGEN} - {The} {ORNL} {Isotope} {Generation} and {Depletion} {Code}},
-	shorttitle = {{ORIGEN}},
-	abstract = {ORIGEN is a versatile point depletion code which solves the equations of radioactive growth and decay for large numbers of isotopes with arbitrary coupling.  The code uses the matrix exponential method to solve a large system of coupled, linear, first-order ordinary differential equations with constant coefficients.  The general nature of the matrix exponential method permits the treatment of complex decay and transmutation schemes.  An extensive library of nuclear data has been compiled, including half-lives and decay schemes, neutron absorbtion, cross sections, fission yields, disintegration energies, and multigroup photon release data.  ORIGEN has been used to compute the compositions and radiactivity of fission products, cladding materials, and fuel materials in LWRs, LMFBRs, MSBRs, and HTGRs.  The applications are illustrated with calculated inventories and radiation levels for spent fuel irradiated to a burnup of 33,000 MWd/metric ton in a PWR spectrum.},
-	number = {ORNL-4628},
-	institution = {Oak Ridge National Laboratory},
-	author = {Bell, M.},
-	month = may,
-	year = {1973},
-	note = {Software, Codes \& Tools},
-	keywords = {Fission, Code, Growth, Cladding, Coupling, Decay, Neutron, ORIGEN, Radiation, Radioactivity, Transmutation, Versatile Point Depletion Code},
-	file = {Bell 1973 ORIGEN.pdf:/Users/gwenchee/Zotero/storage/FUJ5IKU7/Bell 1973 ORIGEN.pdf:application/pdf}
-}
-
 @inproceedings{huff_dynamic_2013,
 	address = {Atlanta, GA, United States},
 	title = {Dynamic {Determination} of {Thermal} {Repository} {Capacity} {For} {Fuel} {Cycle} {Analysis}},
@@ -93,7 +17,38 @@ more detailed model.},
 	month = jun,
 	year = {2013},
 	pages = {123--126},
-	file = {trans_v108_n1_pp123-126 (1).pdf:/Users/gwenchee/Zotero/storage/3I456PBS/trans_v108_n1_pp123-126 (1).pdf:application/pdf}
+	file = {trans_v108_n1_pp123-126 (1).pdf:/Users/khuff/Zotero/storage/3I456PBS/trans_v108_n1_pp123-126 (1).pdf:application/pdf}
+}
+
+@article{carlsen_cycamore_2014,
+	title = {Cycamore v1.0.0},
+	url = {http://figshare.com/articles/Cycamore_v1_0_0/1041829},
+	doi = {http://figshare.com/articles/Cycamore_v1_0_0/1041829},
+	abstract = {Additional module for Cyclus, the nuclear fuel cycle simulator developed at the University of Wisconsin - Madison, supporting the modeling of innovative fuel cycles.},
+	urldate = {2014-06-03},
+	journal = {Figshare},
+	author = {Carlsen, Robert W. and Gidden, Matthew and Huff, Kathryn and Opotowsky, Arrielle C. and Rakhimov, Olzhas and Scopatz, Anthony M. and Wilson, Paul},
+	month = jun,
+	year = {2014},
+	note = {http://figshare.com/articles/Cycamore\_v1\_0\_0/1041829},
+	keywords = {Nuclear Fuel Cycle, agent-based simulation},
+	file = {cycamore_1.0.0:/Users/khuff/Zotero/storage/W2VGZTDV/Scopatz et al. - 2014 - Cycamore v1.0.0:application/zip;Figshare Download:/Users/khuff/Zotero/storage/WQD2B5KA/Scopatz et al. - 2014 - Cycamore v1.0.0:application/zip;Figshare Snapshot:/Users/khuff/Zotero/storage/N44XFGRX/Scopatz et al. - 2014 - Cycamore v1.0.0.html:text/html;Full Text (HTML):/Users/khuff/Zotero/storage/H56U7DUZ/Scopatz et al. - 2014 - Cycamore v1.0.0.html:text/html}
+}
+
+@article{carlsen_cyclus_2014,
+	title = {Cyclus v1.0.0},
+	url = {http://figshare.com/articles/Cyclus_v1_0_0/1041745},
+	doi = {http://dx.doi.org/10.6084/m9.figshare.1041745},
+	abstract = {Cyclus is the next-generation agent-based nuclear fuel cycle simulator, providing flexibility to users and developers through adynamic resource exchange solver and plug-in, user-developed agent framework.
+The goal of Cyclus is to enable a broad spectrum of fuel cycle simulation while providing a low barrier to entry for new users and agent developers. Cyclus engages with potential module developers and encourages them to join a vibrant community in anexpanding ecosystem. Users and developers are always welcome and encouraged to use or contribute to the Cyclus project.},
+	urldate = {2014-06-24},
+	journal = {Figshare},
+	author = {Carlsen, Robert W. and Gidden, Matthew and Huff, Kathryn and Opotowsky, Arrielle C. and Rakhimov, Olzhas and Scopatz, Anthony M. and Welch, Zach and Wilson, Paul},
+	month = jun,
+	year = {2014},
+	note = {http://dx.doi.org/10.6084/m9.figshare.1041745},
+	keywords = {Nuclear fuel cycle, agent-based simulation},
+	file = {cyclus_1.0.0:/Users/khuff/Zotero/storage/HW2QA8MN/Carlsen et al. - 2014 - Cyclus v1.0.0.zip:application/zip;cyclus_1.0.0:/Users/khuff/Zotero/storage/BDXXRM7B/Carlsen et al. - 2014 - Cyclus v1.0.0.zip:application/zip;Figshare Download:/Users/khuff/Zotero/storage/5MZCI93N/Carlsen et al. - 2014 - Cyclus v1.0.0.zip:application/zip;Figshare Download:/Users/khuff/Zotero/storage/NN545PPD/Carlsen et al. - 2014 - Cyclus v1.0.0.zip:application/zip;Figshare Snapshot:/Users/khuff/Zotero/storage/SEA6MHKH/1041745.html:text/html;Figshare Snapshot:/Users/khuff/Zotero/storage/T982H6ZW/1041745.html:text/html;Full Text (HTML):/Users/khuff/Zotero/storage/H2K87S9S/1041745.html:text/html;Full Text (HTML):/Users/khuff/Zotero/storage/QSIAAMM8/1041745.html:text/html}
 }
 
 @article{huff_fundamental_2016,
@@ -109,17 +64,61 @@ more detailed model.},
 	month = apr,
 	year = {2016},
 	note = {arXiv: 1509.03604},
-	keywords = {agent based modeling, and Science, Computer Science - Computational Engineering, Computer Science - Computational Engineering, Finance, and Science, Computer Science - Mathematical Software, Computer Science - Multiagent Systems, Computer Science - Software Engineering, D.2.13, D.2.4, Finance, I.6.7, I.6.8, nuclear engineering, Nuclear fuel cycle, Object orientation, simulation, Systems analysis},
+	keywords = {Computer Science - Computational Engineering, Finance, and Science, Computer Science - Mathematical Software, Computer Science - Multiagent Systems, Computer Science - Software Engineering, D.2.13, D.2.4, I.6.7, I.6.8, Nuclear fuel cycle, Systems analysis, agent based modeling, Object orientation, and Science, Computer Science - Computational Engineering, Finance, nuclear engineering, simulation},
 	pages = {46--59},
-	annote = {arXiv: 1509.03604},
-	file = {arXiv\:1509.03604 PDF:/Users/gwenchee/Zotero/storage/F9KVM9DZ/Huff et al. - 2015 - Fundamental Concepts in the Cyclus Fuel Cycle Simu.pdf:application/pdf;arXiv\:1509.03604 PDF:/Users/gwenchee/Zotero/storage/4FI3T63Q/Huff et al. - 2015 - Fundamental Concepts in the Cyclus Fuel Cycle Simu.pdf:application/pdf;arXiv\:1509.03604 PDF:/Users/gwenchee/Zotero/storage/GN7WIP38/Huff et al. - 2016 - Fundamental concepts in the Cyclus nuclear fuel cy.pdf:application/pdf;arXiv.org Snapshot:/Users/gwenchee/Zotero/storage/HXSDS7VW/1509.html:text/html;arXiv.org Snapshot:/Users/gwenchee/Zotero/storage/WQVTXAN2/1509.html:text/html;arXiv.org Snapshot:/Users/gwenchee/Zotero/storage/EVFA3LC6/1509.html:text/html;fundamentals.pdf:/Users/gwenchee/Zotero/storage/C6G4NQJH/fundamentals.pdf:application/pdf;fundamentals.pdf:/Users/gwenchee/Zotero/storage/BRJECDWC/fundamentals.pdf:application/pdf;ScienceDirect Full Text PDF:/Users/gwenchee/Zotero/storage/E7DK64AA/Huff et al. - 2016 - Fundamental concepts in the Cyclus nuclear fuel cy.pdf:application/pdf;ScienceDirect Snapshot:/Users/gwenchee/Zotero/storage/63CHUQ54/login.html:text/html;ScienceDirect Snapshot:/Users/gwenchee/Zotero/storage/JCCZAZB3/S0965997816300229.html:text/html;ScienceDirect Snapshot:/Users/gwenchee/Zotero/storage/EVBNKXMA/S0965997816300229.html:text/html}
+	file = {arXiv\:1509.03604 PDF:/Users/khuff/Zotero/storage/4FI3T63Q/Huff et al. - 2015 - Fundamental Concepts in the Cyclus Fuel Cycle Simu.pdf:application/pdf;arXiv\:1509.03604 PDF:/Users/khuff/Zotero/storage/F9KVM9DZ/Huff et al. - 2015 - Fundamental Concepts in the Cyclus Fuel Cycle Simu.pdf:application/pdf;arXiv\:1509.03604 PDF:/Users/khuff/Zotero/storage/GN7WIP38/Huff et al. - 2016 - Fundamental concepts in the Cyclus nuclear fuel cy.pdf:application/pdf;arXiv.org Snapshot:/Users/khuff/Zotero/storage/WQVTXAN2/1509.html:text/html;arXiv.org Snapshot:/Users/khuff/Zotero/storage/HXSDS7VW/1509.html:text/html;arXiv.org Snapshot:/Users/khuff/Zotero/storage/EVFA3LC6/1509.html:text/html;fundamentals.pdf:/Users/khuff/Zotero/storage/BRJECDWC/fundamentals.pdf:application/pdf;fundamentals.pdf:/Users/khuff/Zotero/storage/C6G4NQJH/fundamentals.pdf:application/pdf;ScienceDirect Full Text PDF:/Users/khuff/Zotero/storage/E7DK64AA/Huff et al. - 2016 - Fundamental concepts in the Cyclus nuclear fuel cy.pdf:application/pdf;ScienceDirect Snapshot:/Users/khuff/Zotero/storage/63CHUQ54/login.html:text/html;ScienceDirect Snapshot:/Users/khuff/Zotero/storage/EVBNKXMA/S0965997816300229.html:text/html;ScienceDirect Snapshot:/Users/khuff/Zotero/storage/JCCZAZB3/S0965997816300229.html:text/html}
+}
+
+@techreport{doe_strategy_2013,
+	address = {Washington D.C., United States},
+	title = {Strategy for the {Management} and {Disposal} of {Used} {Nuclear} {Fuel} and {High}-{Level} {Radioactive} {Waste}},
+	url = {http://energy.gov/downloads/strategy-management-and-disposal-used-nuclear-fuel-and-high-level-radioactive-waste},
+	urldate = {2013-02-01},
+	institution = {United States Department of Energy},
+	author = {{DOE}},
+	month = jan,
+	year = {2013},
+	file = {2013 1-15 Nuclear_Waste_Report.pdf:/Users/khuff/Zotero/storage/P93IDV6R/2013 1-15 Nuclear_Waste_Report.pdf:application/pdf;doe_strategy_2013.pdf:/Users/khuff/Zotero/storage/GITPI2GM/doe_strategy_2013.pdf:application/pdf;Snapshot:/Users/khuff/Zotero/storage/RBC8D4NG/strategy-management-and-disposal-used-nuclear-fuel-and-high-level-radioactive-waste.html:text/html}
+}
+
+@techreport{wilson_adoption_2009,
+	title = {The {Adoption} of {Advanced} {Fuel} {Cycle} {Technology} {Under} a {Single} {Repository} {Policy}},
+	institution = {University of Wisconsin -- Madison},
+	author = {Wilson, P.},
+	year = {2009}
+}
+
+@article{wigeland_separations_2006,
+	title = {Separations and {Transmutation} {Criteria} to {Improve} {Utilization} of a {Geologic} {Repository}},
+	volume = {154},
+	journal = {Nuclear Technology},
+	author = {Wigeland, Roald A. and Bauer, Theodore H. and Fanning, Thomas H. and Morris, Edgar E.},
+	month = apr,
+	year = {2006},
+	keywords = {Geologic Repository, Spent-Fuel Processing, Thermal Limits},
+	pages = {95--106},
+	file = {NT-Wigeland-Repository-Benefit.pdf:/Users/khuff/Zotero/storage/HI3B9NS8/NT-Wigeland-Repository-Benefit.pdf:application/pdf}
+}
+
+@techreport{bell_origen_1973,
+	title = {{ORIGEN} - {The} {ORNL} {Isotope} {Generation} and {Depletion} {Code}},
+	shorttitle = {{ORIGEN}},
+	abstract = {ORIGEN is a versatile point depletion code which solves the equations of radioactive growth and decay for large numbers of isotopes with arbitrary coupling.  The code uses the matrix exponential method to solve a large system of coupled, linear, first-order ordinary differential equations with constant coefficients.  The general nature of the matrix exponential method permits the treatment of complex decay and transmutation schemes.  An extensive library of nuclear data has been compiled, including half-lives and decay schemes, neutron absorbtion, cross sections, fission yields, disintegration energies, and multigroup photon release data.  ORIGEN has been used to compute the compositions and radiactivity of fission products, cladding materials, and fuel materials in LWRs, LMFBRs, MSBRs, and HTGRs.  The applications are illustrated with calculated inventories and radiation levels for spent fuel irradiated to a burnup of 33,000 MWd/metric ton in a PWR spectrum.},
+	number = {ORNL-4628},
+	institution = {Oak Ridge National Laboratory},
+	author = {Bell, M.},
+	month = may,
+	year = {1973},
+	note = {Software, Codes \& Tools},
+	keywords = {Cladding, Code, Coupling, Decay, Fission, Growth, Neutron, ORIGEN, Radiation, Radioactivity, Transmutation, Versatile Point Depletion Code},
+	file = {Bell 1973 ORIGEN.pdf:/Users/khuff/Zotero/storage/FUJ5IKU7/Bell 1973 ORIGEN.pdf:application/pdf}
 }
 
 @inproceedings{bae_synergistic_2017,
 	address = {Washington, D.C.},
 	title = {Synergistic {Spent} {Nuclear} {Fuel} {Dynamics} {Within} the {European} {Union}},
 	abstract = {The French strategy recommended by 2012-2015 Commission
-Nationale d’Evaluation reports [1] emphasizes preparation
+Nationale d{\textquoteright}Evaluation reports [1] emphasizes preparation
 for a transition from Light Water Reactors (LWRs) to
 Sodium-Cooled Fast Reactors (SFRs). This paper uses Cyclus
 to explore the feasibility of using Used Nuclear Fuel (UNF)
@@ -135,7 +134,7 @@ of additional LWRs by accepting UNF from other EU nations.},
 	author = {Bae, Jin Whan and Huff, Kathryn and Singer, Clifford},
 	month = oct,
 	year = {2017},
-	file = {europe_nuclear_paper.pdf:/Users/gwenchee/Zotero/storage/ZP787VN4/europe_nuclear_paper.pdf:application/pdf;europe_nuclear_paper.pdf:/Users/gwenchee/Zotero/storage/KEJMSZTE/europe_nuclear_paper.pdf:application/pdf;europe_nuclear_paper.pdf:/Users/gwenchee/Zotero/storage/LGFAP2BG/europe_nuclear_paper.pdf:application/pdf;europe_nuclear_paper.pdf:/Users/gwenchee/Zotero/storage/MKKTZAGM/europe_nuclear_paper.pdf:application/pdf;europe_nuclear_paper.pdf:/Users/gwenchee/Zotero/storage/NLNAKMUG/europe_nuclear_paper.pdf:application/pdf}
+	file = {europe_nuclear_paper.pdf:/Users/khuff/Zotero/storage/KEJMSZTE/europe_nuclear_paper.pdf:application/pdf;europe_nuclear_paper.pdf:/Users/khuff/Zotero/storage/LGFAP2BG/europe_nuclear_paper.pdf:application/pdf;europe_nuclear_paper.pdf:/Users/khuff/Zotero/storage/MKKTZAGM/europe_nuclear_paper.pdf:application/pdf;europe_nuclear_paper.pdf:/Users/khuff/Zotero/storage/NLNAKMUG/europe_nuclear_paper.pdf:application/pdf;europe_nuclear_paper.pdf:/Users/khuff/Zotero/storage/ZP787VN4/europe_nuclear_paper.pdf:application/pdf}
 }
 
 @article{peterson_unf-st&dards_2017,
@@ -146,7 +145,7 @@ of additional LWRs by accepting UNF from other EU nations.},
 	author = {Peterson, Josh and van den Akker, Bret and Cumberland, Riley and Miller, Paul and Banerjee, Kaushik},
 	year = {2017},
 	pages = {310--319},
-	file = {Fulltext:/Users/gwenchee/Zotero/storage/CUXQ46R8/00295450.2017.html:text/html;Peterson et al. - 2017 - UNF-ST&DARDS Unified Database and the Automatic Do.pdf:/Users/gwenchee/Zotero/storage/AJUWFE6I/Peterson et al. - 2017 - UNF-ST&DARDS Unified Database and the Automatic Do.pdf:application/pdf;Snapshot:/Users/gwenchee/Zotero/storage/ZTL5PK5U/00295450.2017.html:text/html}
+	file = {Fulltext:/Users/khuff/Zotero/storage/CUXQ46R8/00295450.2017.html:text/html;Peterson et al. - 2017 - UNF-ST&DARDS Unified Database and the Automatic Do.pdf:/Users/khuff/Zotero/storage/AJUWFE6I/Peterson et al. - 2017 - UNF-ST&DARDS Unified Database and the Automatic Do.pdf:application/pdf;Snapshot:/Users/khuff/Zotero/storage/ZTL5PK5U/00295450.2017.html:text/html}
 }
 
 @techreport{huff_extensions_2014,
@@ -154,7 +153,7 @@ of additional LWRs by accepting UNF from other EU nations.},
 	institution = {Lawrence Livermore National Laboratory (LLNL), Livermore, CA},
 	author = {Huff, K. D. and Fratoni, M. and Greenberg, H. R.},
 	year = {2014},
-	file = {huff_extensions_2014.pdf:/Users/gwenchee/Zotero/storage/MV2TCELS/huff_extensions_2014.pdf:application/pdf}
+	file = {huff_extensions_2014.pdf:/Users/khuff/Zotero/storage/MV2TCELS/huff_extensions_2014.pdf:application/pdf}
 }
 
 @techreport{francis_reactor_2015,
@@ -167,7 +166,23 @@ of additional LWRs by accepting UNF from other EU nations.},
 	month = feb,
 	year = {2015},
 	doi = {10.2172/1185693},
-	file = {Francis et al. - 2015 - Reactor Fuel Isotopics and Code Validation for Nuc.pdf:/Users/gwenchee/Zotero/storage/HZLL88N2/Francis et al. - 2015 - Reactor Fuel Isotopics and Code Validation for Nuc.pdf:application/pdf}
+	file = {Francis et al. - 2015 - Reactor Fuel Isotopics and Code Validation for Nuc.pdf:/Users/khuff/Zotero/storage/HZLL88N2/Francis et al. - 2015 - Reactor Fuel Isotopics and Code Validation for Nuc.pdf:application/pdf}
+}
+
+@misc{noauthor_jupyter_nodate,
+	title = {The {Jupyter} {Notebook} - {IPython}},
+	url = {https://ipython.org/notebook.html},
+	urldate = {2018-06-01},
+	file = {The Jupyter Notebook {\textemdash} IPython:/Users/khuff/Zotero/storage/MG54KYIT/notebook.html:text/html}
+}
+
+@misc{ronacher_welcome_2018,
+	title = {Welcome to {Jinja}2 - {Jinja}2 {Documentation} (2.10)},
+	url = {http://jinja.pocoo.org/docs/2.10/},
+	urldate = {2018-06-01},
+	author = {Ronacher},
+	year = {2018},
+	file = {Welcome to Jinja2 {\textemdash} Jinja2 Documentation (2.10):/Users/khuff/Zotero/storage/3CE4W9UW/2.html:text/html}
 }
 
 @misc{iaea_pris_2017,
@@ -176,23 +191,7 @@ of additional LWRs by accepting UNF from other EU nations.},
 	urldate = {2018-06-01},
 	author = {IAEA},
 	year = {2017},
-	file = {PRIS - Home:/Users/gwenchee/Zotero/storage/4H5378XB/home.html:text/html}
-}
-
-@misc{ronacher_welcome_2018,
-	title = {Welcome to {Jinja}2 — {Jinja}2 {Documentation} (2.10)},
-	url = {http://jinja.pocoo.org/docs/2.10/},
-	urldate = {2018-06-01},
-	author = {Ronacher},
-	year = {2018},
-	file = {Welcome to Jinja2 — Jinja2 Documentation (2.10):/Users/gwenchee/Zotero/storage/3CE4W9UW/2.html:text/html}
-}
-
-@misc{noauthor_jupyter_nodate,
-	title = {The {Jupyter} {Notebook} — {IPython}},
-	url = {https://ipython.org/notebook.html},
-	urldate = {2018-06-01},
-	file = {The Jupyter Notebook — IPython:/Users/gwenchee/Zotero/storage/MG54KYIT/notebook.html:text/html}
+	file = {PRIS - Home:/Users/khuff/Zotero/storage/4H5378XB/home.html:text/html}
 }
 
 @misc{chee_arfc/transition-scenarios_2018,
@@ -208,23 +207,23 @@ of additional LWRs by accepting UNF from other EU nations.},
 	doi = {10.5281/zenodo.1287986}
 }
 
-@misc{gehin_nuclear_2016,
-	address = {Knoxville, TN, United States},
-	title = {Nuclear {Power} {Reactors} – {An} {Example} of {Improvements} in {Reliability} and {Potential} for {Improvement}},
-	url = {https://neutrons2.ornl.gov/conf/arw2015/presentations/B%20-%20Gehin%20-%20Nuclear%20Power%20Reactors%20%E2%80%93%20An%20Example%20of%20Improvements%20in%20Reliability%20and%20Potential%20for%20Improvement.pdf},
-	urldate = {2018-06-10},
-	author = {Gehin, Jess},
-	month = apr,
-	year = {2016},
-	file = {B - Gehin - Nuclear Power Reactors – An Example of Improvements in Reliability and Potential for Improvement.pdf:/Users/gwenchee/Zotero/storage/7KVMBDC7/B - Gehin - Nuclear Power Reactors – An Example of Improvements in Reliability and Potential for Improvement.pdf:application/pdf}
-}
-
 @article{iaea_current_nodate,
 	title = {Current {Trends} in {Nuclear} {Fuel} for {Power} {Reactors}},
 	language = {en},
 	author = {IAEA},
 	pages = {11},
-	file = {Current Trends in Nuclear Fuel for Power Reactors.pdf:/Users/gwenchee/Zotero/storage/X5R5RPFR/Current Trends in Nuclear Fuel for Power Reactors.pdf:application/pdf}
+	file = {Current Trends in Nuclear Fuel for Power Reactors.pdf:/Users/khuff/Zotero/storage/X5R5RPFR/Current Trends in Nuclear Fuel for Power Reactors.pdf:application/pdf}
+}
+
+@misc{gehin_nuclear_2016,
+	address = {Knoxville, TN, United States},
+	title = {Nuclear {Power} {Reactors} - {An} {Example} of {Improvements} in {Reliability} and {Potential} for {Improvement}},
+	url = {https://neutrons2.ornl.gov/conf/arw2015/presentations/B%20-%20Gehin%20-%20Nuclear%20Power%20Reactors%20%E2%80%93%20An%20Example%20of%20Improvements%20in%20Reliability%20and%20Potential%20for%20Improvement.pdf},
+	urldate = {2018-06-10},
+	author = {Gehin, Jess},
+	month = apr,
+	year = {2016},
+	file = {B - Gehin - Nuclear Power Reactors {\textendash} An Example of Improvements in Reliability and Potential for Improvement.pdf:/Users/khuff/Zotero/storage/7KVMBDC7/B - Gehin - Nuclear Power Reactors {\textendash} An Example of Improvements in Reliability and Potential for Improvement.pdf:application/pdf}
 }
 
 @article{peterson_additional_2017,
@@ -234,7 +233,7 @@ of additional LWRs by accepting UNF from other EU nations.},
 	shorttitle = {Additional {Capability} {Being} {Developed} from {UNF}-{ST}\&{DARDS} {Unified} {Database}},
 	url = {https://www.tandfonline.com/doi/full/10.1080/00295450.2017.1354551},
 	doi = {10.1080/00295450.2017.1354551},
-	abstract = {The Used Nuclear Fuel Storage, Transportation \& Disposal Analysis Resource and Data System (UNF-ST\&DARDS) is being developed for the U.S. Department of Energy’s Office of Nuclear Energy by the national laboratories. An important part of UNF-ST\&DARDS is the Unified Database (UDB), which contains information that can support a variety of activities including fuel storage, fuel transportation, and disposal-related system analysis. Currently, the main application of the UDB is to support evaluation of the characteristics of discharged spent nuclear fuel (SNF) from the U.S. commercial reactors. However, because of the extensive amount of data that has been collected and analyzed for UNFST\&DARDS, there are many more applications that can utilize the UDB including system analysis with the Next-Generation System Analysis Model (NGSAM) and fuel cycle analysis with fuel cycle simulation codes such as ORION. Going forward, NGSAM and fuel cycle transition analysis with ORION integrate UDB data wherever possible in the UDB’s development plan. These advances in NGSAM and fuel cycle analysis can be used in conjunction with the UDB to help answer more complex questions about the optimization, utilization, storage, and eventual disposal of SNF.},
+	abstract = {The Used Nuclear Fuel Storage, Transportation \& Disposal Analysis Resource and Data System (UNF-ST\&DARDS) is being developed for the U.S. Department of Energy{\textquoteright}s Office of Nuclear Energy by the national laboratories. An important part of UNF-ST\&DARDS is the Unified Database (UDB), which contains information that can support a variety of activities including fuel storage, fuel transportation, and disposal-related system analysis. Currently, the main application of the UDB is to support evaluation of the characteristics of discharged spent nuclear fuel (SNF) from the U.S. commercial reactors. However, because of the extensive amount of data that has been collected and analyzed for UNFST\&DARDS, there are many more applications that can utilize the UDB including system analysis with the Next-Generation System Analysis Model (NGSAM) and fuel cycle analysis with fuel cycle simulation codes such as ORION. Going forward, NGSAM and fuel cycle transition analysis with ORION integrate UDB data wherever possible in the UDB{\textquoteright}s development plan. These advances in NGSAM and fuel cycle analysis can be used in conjunction with the UDB to help answer more complex questions about the optimization, utilization, storage, and eventual disposal of SNF.},
 	language = {en},
 	number = {3},
 	urldate = {2018-08-15},
@@ -243,7 +242,7 @@ of additional LWRs by accepting UNF from other EU nations.},
 	month = sep,
 	year = {2017},
 	pages = {320--329},
-	file = {Peterson et al. - 2017 - Additional Capability Being Developed from UNF-ST&.pdf:/Users/gwenchee/Zotero/storage/Z5UEBNAP/Peterson et al. - 2017 - Additional Capability Being Developed from UNF-ST&.pdf:application/pdf}
+	file = {Peterson et al. - 2017 - Additional Capability Being Developed from UNF-ST&.pdf:/Users/khuff/Zotero/storage/Z5UEBNAP/Peterson et al. - 2017 - Additional Capability Being Developed from UNF-ST&.pdf:application/pdf}
 }
 
 @misc{eia_spent_2015,
@@ -254,5 +253,5 @@ of additional LWRs by accepting UNF from other EU nations.},
 	author = {EIA},
 	month = dec,
 	year = {2015},
-	file = {Table 3. Annual commercial spent fuel discharges and burnup:/Users/gwenchee/Zotero/storage/LVKAHR95/ussnftab3.html:text/html}
+	file = {Table 3. Annual commercial spent fuel discharges and burnup:/Users/khuff/Zotero/storage/LVKAHR95/ussnftab3.html:text/html}
 }

--- a/docs/chee-predicting-ans.tex
+++ b/docs/chee-predicting-ans.tex
@@ -72,13 +72,13 @@ closely replicate reality.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \section{Methodology}
-\subsection{\textit{Generating \Cyclus Simulation and Analysis}}
+\subsection{\textit{\Cyclus Simulation and Analysis}}
 A \Cyclus simulation of the United States nuclear fuel cycle was created using 
 published data of the 112 commerical nuclear reactors that have operated since 
 1967 in the United States. The reactor deployment data was obtained from the 
 Power Reactor Information System (PRIS) reactor database \cite{IAEA_pris_2017}. 
 Relevant data includes country, reactor unit, reactor type, net capacity (MWe), 
-first grid date and shutdown date. United States' reactor data was extracted 
+first grid date, and shutdown date. United States' reactor data was extracted 
 and used to populate the \Cyclus simulation. The recipes used in the \Cyclus 
 simulations are taken from a reference depletion calculation done using ORIGEN 
 \cite{bell_origen_1973} for burnups of 51 and 33 GWDt/MTU. They were also used 
@@ -100,7 +100,7 @@ The assumptions made for this \Cyclus simulation include:
 The UDB database contains commercial SNF information from 1967 through 2013. 
 Data such as initial enrichment, burnup, mass of spent fuel and discharged 
 dates were collected from multiple sources \cite{peterson_additional_2017}. 
-Whereas, data such as isotopic compositions, heat and activity were determined 
+Meanwhile, data such as isotopic compositions, heat and activity were determined 
 by performing irradiation and decay calculations on every fuel assembly based 
 on the collected data. 
 
@@ -119,12 +119,13 @@ spent fuel mass.
 \subsection{\textit{Cumulative Total Spent Fuel Mass Comparison}}
 Figure \ref{fig:total_original} shows the cumulative spent fuel mass for both 
 \Cyclus and UDB data from 1967 to 2013. The spent fuel mass estimated by 
-\Cyclus is larger than UDB data before the year 2000 and diverges after, with 
-UDB being larger. The discrepancies can be attributed to rigidity of \Cyclus 
-simulation input with respect to cycle and refuel time. In \Cyclus, the user 
-specifies refuel and cycle times for each reactor as constant integer months. 
-In reality, the cycle and refuel times vary throughout each reactor's lifetime 
-and are not exact integer multiples of one month. 
+\Cyclus is larger than the UDB calculation before the year 2000. After 2000,
+the UDB calculation reports a larger spent fuel mass. The discrepancies can be 
+attributed to rigidity of \Cyclus simulation input with respect to cycle and 
+refueling duration. In \Cyclus, the user specifies refueling and cycle times for each 
+reactor as constant integer months.  In reality, the cycle and refueling durations 
+vary throughout each reactor's lifetime and are not exact integer multiples of 
+one month. 
 
 \begin{figure}[t] % replace 't' with 'b' to force it to be on the bottom
 	\centering
@@ -133,20 +134,20 @@ and are not exact integer multiples of one month.
 	\label{fig:total_original}
 \end{figure}
 
-The Nuclear Energy Institute (NEI) reported that there has been significant 
-variance in the refueling period for reactors in the United States. The average 
-refuelling time in 1990 was 104 days, and generally decreased to an average 
+The Nuclear Energy Institute (NEI) reported significant 
+variance in the refueling period for reactors in the United States. While average 
+refuelling time in 1990 was 104 days, it decreased to an average 
 refuelling time of 35 days in 2017 \cite{iaea_current_nodate}.
 
 Figure \ref{fig:total_refueltime} includes plots of total spent fuel mass from 
-\Cyclus simulations where refuel time is increased. A longer refuel time brings 
+\Cyclus simulations where refueling duration is increased. A longer refueling duration brings 
 the total spent fuel mass from \Cyclus simulations closer to the UDB data 
 before 2000. 
 
 \begin{figure}[t] 
 	\centering
 	\includegraphics[width=0.48\textwidth]{figures/total_cumulative_mass_spent_fuel_refueltime}
-	\caption{The total cumulative spent fuel mass against discharge time for \Cyclus and UDB data from 1967 through 2013 for various refueling times.}
+	\caption{The total cumulative spent fuel mass against discharge time for \Cyclus and UDB data from 1967 through 2013 for various refueling durations.}
 	\label{fig:total_refueltime}
 \end{figure} 
 
@@ -158,20 +159,20 @@ before 2000.
 \end{figure} 
 
 The larger cumulative UDB spent fuel mass compared to the \Cyclus simulation 
-after 2000 can be attributed to the real world cycle lengths being shorter than 
-the 18 month length of \Cyclus simulations. The United States DOE reported that 
-there was a downward trend of forced outage rates of nuclear reactors from 2000 
-to 2014. The forced outage rate was 4.24\% in 2000 and 2.98\% in 2013 
-\cite{gehin_nuclear_2016}. As the rate of forced outages decreased from 2000 to 
-2013, the cycle length also decreased. 
+after 2000 can be attributed to the real world cycle lengths being shorter on 
+average than the 18 month cycle time assumed in the  \Cyclus simulations. The 
+United States DOE reported that there was a downward trend of forced outage 
+rates of nuclear reactors from 2000 to 2014. The forced outage rate was 4.24\% 
+in 2000 and 2.98\% in 2013 \cite{gehin_nuclear_2016}. As the rate of forced 
+outages decreased from 2000 to 2013, the cycle length also decreased. 
 
-Figure \ref{fig:total_cycletime} includes plots of total spent fuel mass from 
-\Cyclus simulations where cycle time is varied. A shorter cycle time brings the 
+Figure \ref{fig:total_cycletime} plots total spent fuel mass from 
+\Cyclus simulations where th varying cycle. A shorter cycle time brings the 
 total spent fuel mass from \Cyclus simulations closer to the UDB data after 
 2000. 
 
 \subsection{\textit{Major Isotopic Composition of  Spent Fuel Mass Comparison}}
-To accurately simulate the U.S. nuclear fuel cycle from 1968 till the present, 
+To accurately simulate the U.S. nuclear fuel cycle from 1968 through the present, 
 it important to use spent fuel recipes that have similar burnup in relation to 
 the U.S. nuclear reactor burnup. 
 
@@ -220,9 +221,10 @@ difference for 33 GWDt/MTU than 51 GWDt/MTU.
 	\label{fig:absolute_diff_all_33}
 \end{figure} 
 
-The impact of burnup on isotopic composition can be seen more clearly by 
-looking at the cumulative spent fuel isotopic mass difference between UDB and 
-\Cyclus data for the year 2000 (figure \ref{fig:absolute_diff_2000}). In figure 
+The 
+cumulative spent fuel isotopic mass difference between UDB and \Cyclus data for 
+the year 2000 (figure \ref{fig:absolute_diff_2000}) demonstrates the impact of 
+burnup on isotopic composition.  In figure 
 \ref{fig:burn_up_real}, at year 2000, the cumulative average U.S. nuclear 
 reactor burnup was very close to 33 GWDt/MTU. Therefore, the difference in 
 burnup between the U.S. nuclear reactor burnup and \Cyclus data burnup was 
@@ -261,14 +263,14 @@ production in the UDB data \cite{peterson_additional_2017}.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \section{Conclusions}
 This work demonstrates that the spent fuel mass and isotopic composition 
-results from the \Cyclus simulation of the United States nuclear fuel cycle 
-closely follow the results from real world metrics. This proves that these 
-results can be used to produce accurate isotopic decay heat contributions and 
+calculated by the \Cyclus simulation of the United States nuclear fuel cycle 
+closely follow the results from real world metrics. This provides confidence 
+that \Cyclus can be used to produce accurate isotopic decay heat contributions and 
 simulate loading of a waste repository based on thermal constraints. However, 
 improvements can be made to more closely replicate reality.  
 
 Further work that would improve the simulation is to give the reactor agent the 
-capability to accept varying cycle lengths, refueling times and spent fuel 
+capability to accept varying cycle lengths, refueling durations and spent fuel 
 recipes. A \Cyclus simulation then can be made to replicate the historic U.S 
 nuclear fuel cycle even more closely by matching the cycle length, refueling 
 time and spent fuel recipes for specific reactors throughout their lifetimes. 
@@ -282,7 +284,7 @@ This research is being performed using funding received from the DOE Office of
 Nuclear Energy's Nuclear Energy University Program (Project 16-10512) 
 "Demand-Driven Cycamore Archetypes". The authors want to thank members of the 
 Advanced Reactors and Fuel Cycles research group (ARFC) at University of 
-Illinois at Urbana Champaign in particular Jin Whan Bae for valuable advice and 
+Illinois at Urbana-Champaign, and Jin Whan Bae in particular, for valuable advice and 
 Gregory Westphal for proofreading. We also thank our colleagues from the 
 \Cyclus community, particularly those in the University of Wisconsin 
 Computational Nuclear Engineering Research Group (CNERG) and the University of 

--- a/docs/chee-predicting-ans.tex
+++ b/docs/chee-predicting-ans.tex
@@ -33,23 +33,60 @@ gchee2@illinois.edu
 \begin{document}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \section{Introduction}
-\Cyclus \cite{carlsen_cyclus_2014}, a fuel cycle simulator, was used to simulate the
-United States' nuclear fuel cycle from 1967 through 2013. The spent nuclear fuel (SNF) inventory from the \Cyclus simulation was compared to the SNF inventory from the U.S Department of Energy (DOE) sponsored Unified Database (UDB) \cite{peterson_unf-st&dards_2017}. The UDB provides comprehensive and consistent technical data on reactor sites and SNF from the beginning of nuclear reactor operation in the United States until 2013. This comparison between \Cyclus and UDB establishes a realistic validation of \Cyclus' capability to produce total spent fuel mass and accurate isotopic compositions that closely match reality.
+\Cyclus \cite{carlsen_cyclus_2014}, a nuclear fuel cycle simulator, was used to simulate the
+United States' nuclear fuel cycle from 1967 through 2013. The spent nuclear 
+fuel (SNF) inventory from the \Cyclus simulation was compared to the SNF 
+inventory from the U.S Department of Energy (DOE) sponsored Unified Database 
+(UDB) \cite{peterson_unf-st&dards_2017}. The UDB provides comprehensive and 
+consistent technical data on reactor sites and SNF from the beginning of 
+nuclear reactor operation in the United States until 2013. This comparison 
+between \Cyclus and UDB establishes a realistic validation of \Cyclus' 
+capability to produce total spent fuel mass and accurate isotopic compositions 
+that closely match reality.
 
 %%% 
 \section{Background}
-\Cyclus is an agent-based fuel cycle simulation framework \cite{huff_fundamental_2016}, which means that each facility in the fuel cycle is modeled as an agent. \Cycamore \cite{carlsen_cycamore_2014} provides agents to represent process physics of various components of the nuclear fuel cycle (e.g. mine, fuel enrichment facility, reactor) \cite{huff_extensions_2014}. The nuclear fuel assemblies tracked within the simulation are recipe-based. Recipes specify mass fractions for each isotope for fresh and spent fuel. They are calculated ahead of time using neutronics depletion analysis tools such as ORIGEN \cite{bell_origen_1973}, then entered directly into the fuel cycle simulation \cite{peterson_additional_2017}. 
+\Cyclus is an agent-based nuclear fuel cycle simulation framework 
+\cite{huff_fundamental_2016}, which means that each entity (i.e. Region, 
+Institution, or Facility) in the fuel cycle is modeled as an agent. 
+\Cycamore \cite{carlsen_cycamore_2014} provides agents to represent process 
+physics of various components of the nuclear fuel cycle (e.g. mine, fuel 
+enrichment facility, reactor) \cite{huff_extensions_2014}. The nuclear fuel 
+assemblies tracked within the simulation are recipe-based. Recipes specify mass 
+fractions for each isotope for fresh and spent fuel. They are calculated ahead 
+of time using neutronics depletion analysis tools such as ORIGEN 
+\cite{bell_origen_1973}, then entered directly into the fuel cycle simulation 
+\cite{peterson_additional_2017}. 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \section{Motivation}
-The United States is currently considering various nuclear fuel cycles and geologic disposal options \cite{DOE_strategy_2013}. Decisions such as waste package spacing, waste repository size and geometry will be influenced by key criteria such as thermal load of waste packages and the thermal capacity of the selected geologic host media. Waste package thermal evolution depends on the decay heat contribution from each isotope in the spent fuel. Therefore, to correctly simulate loading of a waste repository based on thermal constraints in \Cyclus, the simulation must first give isotopic compositions and spent fuel masses that closely replicate reality. 
+The United States is currently considering various and geologic disposal 
+options \cite{DOE_strategy_2013}. Decisions such as waste package spacing, 
+waste repository size, and geometry will be influenced by key criteria such as 
+thermal load of waste packages and the thermal capacity of the selected 
+geologic host media. Waste package thermal evolution depends on the decay heat 
+contribution from each isotope in the spent fuel. Therefore, to correctly 
+simulate loading of a waste repository based on thermal constraints in \Cyclus, 
+the simulation must first give isotopic compositions and spent fuel masses that 
+closely replicate reality. 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \section{Methodology}
 \subsection{\textit{Generating \Cyclus Simulation and Analysis}}
-A \Cyclus simulation of the United States nuclear fuel cycle was created using published data of the 112 commerical nuclear reactors that have operated since 1967 in the United States. The reactor deployment data was obtained from the Power Reactor Information System (PRIS) reactor database \cite{IAEA_pris_2017}. Relevant data includes country, reactor unit, reactor type, net capacity (MWe), first grid date and shutdown date. United States' reactor data was extracted and used to populate the \Cyclus simulation. The recipes used in the \Cyclus simulations are taken from a reference depletion calculation done using ORIGEN \cite{bell_origen_1973} for burnups of 51 and 33 GWDt/MTU. They were also used in \cite{wilson_adoption_2009, bae_synergistic_2017}. 
+A \Cyclus simulation of the United States nuclear fuel cycle was created using 
+published data of the 112 commerical nuclear reactors that have operated since 
+1967 in the United States. The reactor deployment data was obtained from the 
+Power Reactor Information System (PRIS) reactor database \cite{IAEA_pris_2017}. 
+Relevant data includes country, reactor unit, reactor type, net capacity (MWe), 
+first grid date and shutdown date. United States' reactor data was extracted 
+and used to populate the \Cyclus simulation. The recipes used in the \Cyclus 
+simulations are taken from a reference depletion calculation done using ORIGEN 
+\cite{bell_origen_1973} for burnups of 51 and 33 GWDt/MTU. They were also used 
+in \cite{wilson_adoption_2009, bae_synergistic_2017}. 
 
-Jinja2 \cite{ronacher_welcome_2018}, a Python templating language, was then used in Python to render the data into an input file that is accepted by \Cyclus. The output file produced by \Cyclus was also analyzed using Python. 
+Jinja2 \cite{ronacher_welcome_2018}, a Python templating language, was then 
+used in Python to render the data into an input file that is accepted by 
+\Cyclus. The output file produced by \Cyclus was also analyzed using Python. 
 
 The assumptions made for this \Cyclus simulation include: 
 
@@ -60,15 +97,34 @@ The assumptions made for this \Cyclus simulation include:
 \end{enumerate}
 
 \subsection{\textit{UDB Data Analysis}}
-The UDB database contains commercial SNF information from 1967 through 2013. Data such as initial enrichment, burnup, mass of spent fuel and discharged dates were collected from multiple sources \cite{peterson_additional_2017}. Whereas, data such as isotopic compositions, heat and activity were determined by performing irradiation and decay calculations on every fuel assembly based on the collected data. 
+The UDB database contains commercial SNF information from 1967 through 2013. 
+Data such as initial enrichment, burnup, mass of spent fuel and discharged 
+dates were collected from multiple sources \cite{peterson_additional_2017}. 
+Whereas, data such as isotopic compositions, heat and activity were determined 
+by performing irradiation and decay calculations on every fuel assembly based 
+on the collected data. 
 
-The UDB dataset used for this work included discharged fuel assembly data per reactor, specific isotopic concentrations and decay heat for each assembly along with its discharge date \cite{peterson_unf-st&dards_2017}. The UDB dataset was imported into Python, processed and compared with \Cyclus simulation output. All scripts and data used are available in \cite{chee_arfc/transition-scenarios_2018}. 
+The UDB dataset used for this work included discharged fuel assembly data per 
+reactor, specific isotopic concentrations and decay heat for each assembly 
+along with its discharge date \cite{peterson_unf-st&dards_2017}. The UDB 
+dataset was imported into Python, processed and compared with \Cyclus 
+simulation output. All scripts and data used are available in 
+\cite{chee_arfc/transition-scenarios_2018}. 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \section{Results and Analysis}
-The primary outcome of this validation is to provide comparisons between \Cyclus data and UDB data for spent fuel mass and isotopic contributions to the spent fuel mass. 
+The primary outcome of this validation is to provide comparisons between 
+\Cyclus data and UDB data for spent fuel mass and isotopic contributions to the 
+spent fuel mass. 
 
 \subsection{\textit{Cumulative Total Spent Fuel Mass Comparison}}
-Figure \ref{fig:total_original} shows the cumulative spent fuel mass for both \Cyclus and UDB data from 1967 to 2013. The spent fuel mass estimated by \Cyclus is larger than UDB data before the year 2000 and diverges after, with UDB being larger. The discrepancies can be attributed to rigidity of \Cyclus simulation input with respect to cycle and refuel time. In \Cyclus, the user specifies refuel and cycle times for each reactor as constant integer months. In reality, the cycle and refuel times vary throughout each reactor's lifetime and are not exact integer multiples of one month. 
+Figure \ref{fig:total_original} shows the cumulative spent fuel mass for both 
+\Cyclus and UDB data from 1967 to 2013. The spent fuel mass estimated by 
+\Cyclus is larger than UDB data before the year 2000 and diverges after, with 
+UDB being larger. The discrepancies can be attributed to rigidity of \Cyclus 
+simulation input with respect to cycle and refuel time. In \Cyclus, the user 
+specifies refuel and cycle times for each reactor as constant integer months. 
+In reality, the cycle and refuel times vary throughout each reactor's lifetime 
+and are not exact integer multiples of one month. 
 
 \begin{figure}[t] % replace 't' with 'b' to force it to be on the bottom
 	\centering
@@ -77,9 +133,15 @@ Figure \ref{fig:total_original} shows the cumulative spent fuel mass for both \C
 	\label{fig:total_original}
 \end{figure}
 
-The Nuclear Energy Institute (NEI) reported that there has been significant variance in the refueling period for reactors in the United States. The average refuelling time in 1990 was 104 days, and generally decreased to an average refuelling time of 35 days in 2017 \cite{iaea_current_nodate}.
+The Nuclear Energy Institute (NEI) reported that there has been significant 
+variance in the refueling period for reactors in the United States. The average 
+refuelling time in 1990 was 104 days, and generally decreased to an average 
+refuelling time of 35 days in 2017 \cite{iaea_current_nodate}.
 
-Figure \ref{fig:total_refueltime} includes plots of total spent fuel mass from \Cyclus simulations where refuel time is increased. A longer refuel time brings the total spent fuel mass from \Cyclus simulations closer to the UDB data before 2000. 
+Figure \ref{fig:total_refueltime} includes plots of total spent fuel mass from 
+\Cyclus simulations where refuel time is increased. A longer refuel time brings 
+the total spent fuel mass from \Cyclus simulations closer to the UDB data 
+before 2000. 
 
 \begin{figure}[t] 
 	\centering
@@ -95,14 +157,31 @@ Figure \ref{fig:total_refueltime} includes plots of total spent fuel mass from \
 	\label{fig:total_cycletime}
 \end{figure} 
 
-The larger cumulative UDB spent fuel mass compared to the \Cyclus simulation after 2000 can be attributed to the real world cycle lengths being shorter than the 18 month length of \Cyclus simulations. The United States DOE reported that there was a downward trend of forced outage rates of nuclear reactors from 2000 to 2014. The forced outage rate was 4.24\% in 2000 and 2.98\% in 2013 \cite{gehin_nuclear_2016}. As the rate of forced outages decreased from 2000 to 2013, the cycle length also decreased. 
+The larger cumulative UDB spent fuel mass compared to the \Cyclus simulation 
+after 2000 can be attributed to the real world cycle lengths being shorter than 
+the 18 month length of \Cyclus simulations. The United States DOE reported that 
+there was a downward trend of forced outage rates of nuclear reactors from 2000 
+to 2014. The forced outage rate was 4.24\% in 2000 and 2.98\% in 2013 
+\cite{gehin_nuclear_2016}. As the rate of forced outages decreased from 2000 to 
+2013, the cycle length also decreased. 
 
-Figure \ref{fig:total_cycletime} includes plots of total spent fuel mass from \Cyclus simulations where cycle time is varied. A shorter cycle time brings the total spent fuel mass from \Cyclus simulations closer to the UDB data after 2000. 
+Figure \ref{fig:total_cycletime} includes plots of total spent fuel mass from 
+\Cyclus simulations where cycle time is varied. A shorter cycle time brings the 
+total spent fuel mass from \Cyclus simulations closer to the UDB data after 
+2000. 
 
 \subsection{\textit{Major Isotopic Composition of  Spent Fuel Mass Comparison}}
-To accurately simulate the U.S. nuclear fuel cycle from 1968 till the present, it important to use spent fuel recipes that have similar burnup in relation to the U.S. nuclear reactor burnup. 
+To accurately simulate the U.S. nuclear fuel cycle from 1968 till the present, 
+it important to use spent fuel recipes that have similar burnup in relation to 
+the U.S. nuclear reactor burnup. 
 
-Figure \ref{fig:burn_up_real} shows the average cumulative burnup for U.S. nuclear reactors from 1968 to 2013 \cite{eia_spent_2015}. Figure \ref{fig:burn_up_difference} shows the difference between burnup of the spent fuel recipes used in the \Cyclus simulations and cumulative burnup of U.S. nuclear reactors as seen in figure \ref{fig:burn_up_real}. On average, spent fuel burnup of 33 GWDt/MTU is closer to the cumulative burnup of U.S. nuclear reactors than 51 GWDt/MTU. 
+Figure \ref{fig:burn_up_real} shows the average cumulative burnup for U.S. 
+nuclear reactors from 1968 to 2013 \cite{eia_spent_2015}. Figure 
+\ref{fig:burn_up_difference} shows the difference between burnup of the spent 
+fuel recipes used in the \Cyclus simulations and cumulative burnup of U.S. 
+nuclear reactors as seen in figure \ref{fig:burn_up_real}. On average, spent 
+fuel burnup of 33 GWDt/MTU is closer to the cumulative burnup of U.S. nuclear 
+reactors than 51 GWDt/MTU. 
 
 \begin{figure}[t] % replace 't' with 'b' to force it to be on the bottom
 	\centering
@@ -118,7 +197,14 @@ Figure \ref{fig:burn_up_real} shows the average cumulative burnup for U.S. nucle
 	\label{fig:burn_up_difference}
 \end{figure} 
 
-Figures \ref{fig:absolute_diff_all_51} and \ref{fig:absolute_diff_all_33} show the cumulative spent fuel isotopic mass difference between UDB and \Cyclus data in 5 year intervals for burnup of 51 GWDt/MTU and 33 GWDt/MTU correspondingly. The \Cyclus data that had 33 GWDt/MTU burnup deviated less compared to the \Cyclus data that had 51 GWDt/MTU burnup. This is apparent for $^{236}$U, $^{242}$Pu and $^{240}$Pu. They are similar for the isotopes on the left side of both figures. With an exception of $^{239}$Pu having a substantial larger difference for 33 GWDt/MTU than 51 GWDt/MTU. 
+Figures \ref{fig:absolute_diff_all_51} and \ref{fig:absolute_diff_all_33} show 
+the cumulative spent fuel isotopic mass difference between UDB and \Cyclus data 
+in 5 year intervals for burnup of 51 GWDt/MTU and 33 GWDt/MTU correspondingly. 
+The \Cyclus data that had 33 GWDt/MTU burnup deviated less compared to the 
+\Cyclus data that had 51 GWDt/MTU burnup. This is apparent for $^{236}$U, 
+$^{242}$Pu and $^{240}$Pu. They are similar for the isotopes on the left side 
+of both figures. With an exception of $^{239}$Pu having a substantial larger 
+difference for 33 GWDt/MTU than 51 GWDt/MTU. 
 
 \begin{figure}[t] % replace 't' with 'b' to force it to be on the bottom
 	\centering
@@ -134,9 +220,20 @@ Figures \ref{fig:absolute_diff_all_51} and \ref{fig:absolute_diff_all_33} show t
 	\label{fig:absolute_diff_all_33}
 \end{figure} 
 
-The impact of burnup on isotopic composition can be seen more clearly by looking at the cumulative spent fuel isotopic mass difference between UDB and \Cyclus data for the year 2000 (figure \ref{fig:absolute_diff_2000}). In figure \ref{fig:burn_up_real}, at year 2000, the cumulative average U.S. nuclear reactor burnup was very close to 33 GWDt/MTU. Therefore, the difference in burnup between the U.S. nuclear reactor burnup and \Cyclus data burnup was around 20 GWDt/MTU for 51 GWDt/MTU burnup and 0 GWDt/MTU for 33 GWDt/MTU burnup (as seen in figure \ref{fig:burn_up_difference}). 
+The impact of burnup on isotopic composition can be seen more clearly by 
+looking at the cumulative spent fuel isotopic mass difference between UDB and 
+\Cyclus data for the year 2000 (figure \ref{fig:absolute_diff_2000}). In figure 
+\ref{fig:burn_up_real}, at year 2000, the cumulative average U.S. nuclear 
+reactor burnup was very close to 33 GWDt/MTU. Therefore, the difference in 
+burnup between the U.S. nuclear reactor burnup and \Cyclus data burnup was 
+around 20 GWDt/MTU for 51 GWDt/MTU burnup and 0 GWDt/MTU for 33 GWDt/MTU burnup 
+(as seen in figure \ref{fig:burn_up_difference}). 
 
-As discussed by Wigeland et al \cite{wigeland_separations_2006}, $^{240}$Pu, $^{239}$Pu and $^{241}$Am are the most significant long-term decay heat contributors to each waste package. While, $^{238}$Pu, $^{244}$Cm, $^{90}$Sr and $^{137}$Cs are the most significant short term decay heat contributors \cite{wigeland_separations_2006} to each waste package. 
+As discussed by Wigeland et al \cite{wigeland_separations_2006}, $^{240}$Pu, 
+$^{239}$Pu and $^{241}$Am are the most significant long-term decay heat 
+contributors to each waste package. While, $^{238}$Pu, $^{244}$Cm, $^{90}$Sr 
+and $^{137}$Cs are the most significant short term decay heat contributors 
+\cite{wigeland_separations_2006} to each waste package. 
 
 \begin{figure}[t] % replace 't' with 'b' to force it to be on the bottom
 	\centering
@@ -145,20 +242,52 @@ As discussed by Wigeland et al \cite{wigeland_separations_2006}, $^{240}$Pu, $^{
 	\label{fig:absolute_diff_2000}
 \end{figure} 
 
-In figure \ref{fig:absolute_diff_2000}, the \Cyclus simulation that uses the 33 GWDt/MTU burnup recipe has a small mass difference between UDB and \Cyclus data for $^{240}$Pu and $^{241}$Am compared to 51 GWDt/MTU burnup. However, it has a substantial difference for $^{239}$Pu. Figure 4 also shows small differences between UDB and \Cyclus data for $^{238}$Pu, $^{244}$Cm, $^{90}$Sr and $^{137}$Cs. 
+In figure \ref{fig:absolute_diff_2000}, the \Cyclus simulation that uses the 33 
+GWDt/MTU burnup recipe has a small mass difference between UDB and \Cyclus data 
+for $^{240}$Pu and $^{241}$Am compared to 51 GWDt/MTU burnup. However, it has a 
+substantial difference for $^{239}$Pu. Figure 4 also shows small differences 
+between UDB and \Cyclus data for $^{238}$Pu, $^{244}$Cm, $^{90}$Sr and 
+$^{137}$Cs. 
 
-The large mass difference between UDB and \Cyclus data (where UDB $^{239}$Pu mass is larger than \Cyclus $^{239}$Pu mass) for $^{239}$Pu in figures \ref{fig:absolute_diff_2000}, \ref{fig:absolute_diff_all_51} and \ref{fig:absolute_diff_all_33} can be attributed to conservative depletion parameters used in the calculations for isotopic compositions in the UDB database \cite{peterson_additional_2017}. These assumptions result in the hardening of the neutron spectrum that results in increased $^{239}$Pu production in the UDB data \cite{peterson_additional_2017}. 
+The large mass difference between UDB and \Cyclus data (where UDB $^{239}$Pu 
+mass is larger than \Cyclus $^{239}$Pu mass) for $^{239}$Pu in figures 
+\ref{fig:absolute_diff_2000}, \ref{fig:absolute_diff_all_51} and 
+\ref{fig:absolute_diff_all_33} can be attributed to conservative depletion 
+parameters used in the calculations for isotopic compositions in the UDB 
+database \cite{peterson_additional_2017}. These assumptions result in the 
+hardening of the neutron spectrum that results in increased $^{239}$Pu 
+production in the UDB data \cite{peterson_additional_2017}. 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \section{Conclusions}
-This work demonstrates that the spent fuel mass and isotopic composition results from the \Cyclus simulation of the United States nuclear fuel cycle closely follow the results from real world metrics. This proves that these results can be used to produce accurate isotopic decay heat contributions and simulate loading of a waste repository based on thermal constraints. However, improvements can be made to more closely replicate reality.  
+This work demonstrates that the spent fuel mass and isotopic composition 
+results from the \Cyclus simulation of the United States nuclear fuel cycle 
+closely follow the results from real world metrics. This proves that these 
+results can be used to produce accurate isotopic decay heat contributions and 
+simulate loading of a waste repository based on thermal constraints. However, 
+improvements can be made to more closely replicate reality.  
 
-Further work that would improve the simulation is to give the reactor agent the capability to accept varying cycle lengths, refueling times and spent fuel recipes. A \Cyclus simulation then can be made to replicate the historic U.S nuclear fuel cycle even more closely by matching the cycle length, refueling time and spent fuel recipes for specific reactors throughout their lifetimes. This will give more accurate spent fuel mass and isotopic compositions which will in turn make the \Cyclus simulations for loading of a waste repository more accurate. 
+Further work that would improve the simulation is to give the reactor agent the 
+capability to accept varying cycle lengths, refueling times and spent fuel 
+recipes. A \Cyclus simulation then can be made to replicate the historic U.S 
+nuclear fuel cycle even more closely by matching the cycle length, refueling 
+time and spent fuel recipes for specific reactors throughout their lifetimes. 
+This will give more accurate spent fuel mass and isotopic compositions which 
+will in turn make the \Cyclus simulations for loading of a waste repository 
+more accurate. 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \section{Acknowledgments}
-This research is being performed using funding received from the DOE Office of Nuclear Energy's
-Nuclear Energy University Program (Project 16-10512) "Demand-Driven Cycamore Archetypes". The authors want to thank members of the Advanced Reactors and Fuel Cycles research group (ARFC) at University of Illinois at Urbana Champaign in particular Jin Whan Bae for valuable advice and Gregory Westphal for proofreading. We also thank our colleagues from the \Cyclus community, particularly those in the University of Wisconsin Computational Nuclear Engineering Research Group (CNERG) and the University of South Carolina Energy Research Group (ERGS) who provided collaborative support in the development of the core software, \Cyclus, enabling this work. 
+This research is being performed using funding received from the DOE Office of 
+Nuclear Energy's Nuclear Energy University Program (Project 16-10512) 
+"Demand-Driven Cycamore Archetypes". The authors want to thank members of the 
+Advanced Reactors and Fuel Cycles research group (ARFC) at University of 
+Illinois at Urbana Champaign in particular Jin Whan Bae for valuable advice and 
+Gregory Westphal for proofreading. We also thank our colleagues from the 
+\Cyclus community, particularly those in the University of Wisconsin 
+Computational Nuclear Engineering Research Group (CNERG) and the University of 
+South Carolina Energy Research Group (ERGS) who provided collaborative support 
+in the development of the core software, \Cyclus, enabling this work. 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \bibliographystyle{ans}

--- a/docs/chee-predicting-ans.tex
+++ b/docs/chee-predicting-ans.tex
@@ -17,6 +17,9 @@ gchee2@illinois.edu
 \usepackage{subcaption}
 \usepackage{enumitem}
 \usepackage{placeins}
+\usepackage[acronym,toc]{glossaries}
+\include{acros}
+\makeglossaries
 \newcommand{\SN}{S$_N$}
 \renewcommand{\vec}[1]{\bm{#1}} %vector is bold italic
 \newcommand{\vd}{\bm{\cdot}} % slightly bold vector dot
@@ -37,12 +40,12 @@ gchee2@illinois.edu
 \section{Introduction}
 \Cyclus \cite{carlsen_cyclus_2014}, a nuclear fuel cycle simulator, was used to simulate the
 United States' nuclear fuel cycle from 1967 through 2013. The spent nuclear 
-fuel (SNF) inventory from the \Cyclus simulation was compared to the SNF 
-inventory from the U.S Department of Energy (DOE) sponsored Unified Database 
-(UDB) \cite{peterson_unf-st&dards_2017}. The UDB provides comprehensive and 
-consistent technical data on reactor sites and SNF from the beginning of 
-nuclear reactor operation in the United States until 2013. This comparison 
-between \Cyclus and UDB establishes a realistic validation of \Cyclus' 
+\gls{SNF} inventory from the \Cyclus simulation was compared to the \gls{SNF} 
+inventory from the \gls{DOE} sponsored \gls{UNFSTANDARDS} \gls{UDB} 
+\cite{peterson_unf-st&dards_2017}. The \gls{UDB} provides comprehensive and 
+consistent technical data on reactor sites and \gls{SNF} from the beginning of 
+nuclear reactor operation in the \gls{US} until 2013. This comparison 
+between \Cyclus and \gls{UDB} establishes a realistic validation of \Cyclus' 
 capability to produce total spent fuel mass and accurate isotopic compositions 
 that closely match reality.
 
@@ -62,7 +65,7 @@ of time using neutronics depletion analysis tools such as ORIGEN
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \section{Motivation}
-The United States is currently considering various and geologic disposal 
+The \gls{US} is currently considering various and geologic disposal 
 options \cite{DOE_strategy_2013}. Decisions such as waste package spacing, 
 waste repository size, and geometry will be influenced by key criteria such as 
 thermal load of waste packages and the thermal capacity of the selected 
@@ -74,16 +77,16 @@ closely replicate reality.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \section{Methodology}
-A \Cyclus simulation of the United States nuclear fuel cycle was created using 
+A \Cyclus simulation of the \gls{US} nuclear fuel cycle was created using 
 published data of the 112 commerical nuclear reactors that have operated since 
-1967 in the United States. The reactor deployment data was obtained from the 
-Power Reactor Information System (PRIS) reactor database \cite{IAEA_pris_2017}. 
-Relevant data includes country, reactor unit, reactor type, net capacity (MWe), 
-first grid date, and shutdown date. United States' reactor data was extracted 
-and used to populate the \Cyclus simulation. The recipes used in the \Cyclus 
-simulations are taken from a reference depletion calculation done using ORIGEN 
-\cite{bell_origen_1973} for burnups of 51 and 33 GWDt/MTU. They were also used 
-in \cite{wilson_adoption_2009, bae_synergistic_2017}. 
+1967 in the \gls{US}. The reactor deployment data was obtained from \gls{PRIS} 
+reactor database \cite{IAEA_pris_2017}.  Relevant data includes country, 
+reactor unit, reactor type, net capacity (MWe), first grid date, and shutdown 
+date. \gls{US}' reactor data was extracted and used to populate the \Cyclus 
+simulation. The recipes used in the \Cyclus simulations are taken from a 
+reference depletion calculation done using ORIGEN \cite{bell_origen_1973} for 
+burnups of 51 and 33 GWD/MTU. They were also used in 
+\cite{wilson_adoption_2009, bae_synergistic_2017}. 
 
 Jinja2 \cite{ronacher_welcome_2018}, a Python templating language, was then 
 used in Python to render the data into an input file that is accepted by 
@@ -97,30 +100,30 @@ The assumptions made for this \Cyclus simulation include:
 	\item There is isotopic decay. 
 \end{enumerate}
 
-The UDB database contains commercial SNF information from 1967 through 2013. 
+The \gls{UDB} database contains commercial \gls{SNF} information from 1967 through 2013. 
 Data such as initial enrichment, burnup, mass of spent fuel and discharged 
 dates were collected from multiple sources \cite{peterson_additional_2017}. 
 Meanwhile, data such as isotopic compositions, heat and activity were determined 
 by performing irradiation and decay calculations on every fuel assembly based 
 on the collected data. 
 
-The UDB dataset used for this work included discharged fuel assembly data per 
+The \gls{UDB} dataset used for this work included discharged fuel assembly data per 
 reactor, specific isotopic concentrations and decay heat for each assembly 
-along with its discharge date \cite{peterson_unf-st&dards_2017}. The UDB 
+along with its discharge date \cite{peterson_unf-st&dards_2017}. The \gls{UDB} 
 dataset was imported into Python, processed and compared with \Cyclus 
 simulation output. All scripts and data used are available in 
 \cite{chee_arfc/transition-scenarios_2018}. 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \section{Results and Analysis}
 The primary outcome of this validation is to provide comparisons between 
-\Cyclus data and UDB data for spent fuel mass and isotopic contributions to the 
+\Cyclus data and \gls{UDB} data for spent fuel mass and isotopic contributions to the 
 spent fuel mass. 
 
 \subsection{\textit{Cumulative Total Spent Fuel Mass Comparison}}
 Figure \ref{fig:total_original} shows the cumulative spent fuel mass for both 
-\Cyclus and UDB data from 1967 to 2013. The spent fuel mass estimated by 
-\Cyclus is larger than the UDB calculation before the year 2000. After 2000,
-the UDB calculation reports a larger spent fuel mass. The discrepancies can be 
+\Cyclus and \gls{UDB} data from 1967 to 2013. The spent fuel mass estimated by 
+\Cyclus is larger than the \gls{UDB} calculation before the year 2000. After 2000,
+the \gls{UDB} calculation reports a larger spent fuel mass. The discrepancies can be 
 attributed to rigidity of \Cyclus simulation input with respect to cycle and 
 refueling duration. In \Cyclus, the user specifies refueling and cycle times for each 
 reactor as constant integer months.  In reality, the cycle and refueling durations 
@@ -130,45 +133,45 @@ one month.
 \begin{figure}[t] % replace 't' with 'b' to force it to be on the bottom
 	\centering
 	\includegraphics[width=0.48\textwidth]{figures/total_cumulative_mass_spent_fuel_original}
-	\caption{The total cumulative spent fuel mass against discharge time for \Cyclus and UDB data from 1967 through 2013.}
+	\caption{The total cumulative spent fuel mass against discharge time for \Cyclus and \gls{UDB} data from 1967 through 2013.}
 	\label{fig:total_original}
 \end{figure}
 
-The Nuclear Energy Institute (NEI) reported significant 
-variance in the refueling period for US reactors. While average 
+The \gls{NEI} reported significant 
+variance in the refueling period for \gls{US} reactors. While average 
 refuelling time in 1990 was 104 days, it decreased to an average 
 refuelling time of 35 days in 2017 \cite{iaea_current_nodate}.
 
 Figure \ref{fig:total_refueltime} includes plots of total spent fuel mass from 
 \Cyclus simulations where refueling duration is increased. A longer refueling duration brings 
-the total spent fuel mass from \Cyclus simulations closer to the UDB data 
+the total spent fuel mass from \Cyclus simulations closer to the \gls{UDB} data 
 before 2000. 
 
 \begin{figure}[t] 
 	\centering
 	\includegraphics[width=0.48\textwidth]{figures/total_cumulative_mass_spent_fuel_refueltime}
-	\caption{The total cumulative spent fuel mass against discharge time for \Cyclus and UDB data from 1967 through 2013 for various refueling durations.}
+	\caption{The total cumulative spent fuel mass against discharge time for \Cyclus and \gls{UDB} data from 1967 through 2013 for various refueling durations.}
 	\label{fig:total_refueltime}
 \end{figure} 
 
 \begin{figure}[b] % replace 't' with 'b' to force it to be on the bottom
 	\centering
 	\includegraphics[width=0.48\textwidth]{figures/total_cumulative_mass_spent_fuel_cycletime}
-	\caption{The total cumulative spent fuel mass against discharge time for \Cyclus and UDB data from 1967 to 2013 for various cycle times.}
+	\caption{The total cumulative spent fuel mass against discharge time for \Cyclus and \gls{UDB} data from 1967 to 2013 for various cycle times.}
 	\label{fig:total_cycletime}
 \end{figure} 
 
-The larger cumulative UDB spent fuel mass compared to the \Cyclus simulation 
+The larger cumulative \gls{UDB} spent fuel mass compared to the \Cyclus simulation 
 after 2000 can be attributed to the real world cycle lengths being shorter on 
 average than the 18 month cycle time assumed in the  \Cyclus simulations. The 
-United States DOE reported that there was a downward trend of forced outage 
+\gls{US} \gls{DOE} reported that there was a downward trend of forced outage 
 rates of nuclear reactors from 2000 to 2014. The forced outage rate was 4.24\% 
 in 2000 and 2.98\% in 2013 \cite{gehin_nuclear_2016}. As the rate of forced 
 outages decreased from 2000 to 2013, the cycle length also decreased. 
 
 Figure \ref{fig:total_cycletime} plots total spent fuel mass from 
 \Cyclus simulations where th varying cycle. A shorter cycle time brings the 
-total spent fuel mass from \Cyclus simulations closer to the UDB data after 
+total spent fuel mass from \Cyclus simulations closer to the \gls{UDB} data after 
 2000. 
 
 \subsection{\textit{Major Isotopic Composition of  Spent Fuel Mass Comparison}}
@@ -181,8 +184,8 @@ nuclear reactors from 1968 to 2013 \cite{eia_spent_2015}. Figure
 \ref{fig:burn_up_difference} shows the difference between burnup of the spent 
 fuel recipes used in the \Cyclus simulations and cumulative burnup of U.S. 
 nuclear reactors as seen in figure \ref{fig:burn_up_real}. On average, spent 
-fuel burnup of 33 GWDt/MTU is closer to the cumulative burnup of U.S. nuclear 
-reactors than 51 GWDt/MTU. 
+fuel burnup of 33 GWD/MTU is closer to the cumulative burnup of U.S. nuclear 
+reactors than 51 GWD/MTU. 
 
 \begin{figure}[t] % replace 't' with 'b' to force it to be on the bottom
 	\centering
@@ -199,13 +202,13 @@ reactors than 51 GWDt/MTU.
 \end{figure} 
 
 Figures \ref{fig:absolute_diff_all_51} and \ref{fig:absolute_diff_all_33} show 
-the cumulative spent fuel isotopic mass difference between UDB and \Cyclus data 
-in 5 year intervals for burnup of 51 GWDt/MTU and 33 GWDt/MTU correspondingly. 
-The \Cyclus data that had 33 GWDt/MTU burnup deviated less compared to the 
-\Cyclus data that had 51 GWDt/MTU burnup. This is apparent for $^{236}$U, 
+the cumulative spent fuel isotopic mass difference between \gls{UDB} and \Cyclus data 
+in 5 year intervals for burnup of 51 GWD/MTU and 33 GWD/MTU correspondingly. 
+The \Cyclus data that had 33 GWD/MTU burnup deviated less compared to the 
+\Cyclus data that had 51 GWD/MTU burnup. This is apparent for $^{236}$U, 
 $^{242}$Pu and $^{240}$Pu. They are similar for the isotopes on the left side 
 of both figures. With an exception of $^{239}$Pu having a substantial larger 
-difference for 33 GWDt/MTU than 51 GWDt/MTU. 
+difference for 33 GWD/MTU than 51 GWD/MTU. 
 
 \begin{figure*}[htb] % replace 't' with 'b' to force it to be on the bottom
 	\centering
@@ -225,20 +228,20 @@ difference for 33 GWDt/MTU than 51 GWDt/MTU.
 	\label{fig:absolute_diff_2000}
         \end{subfigure}
         \caption{The absolute difference between spent fuel mass calculated by 
-        UDB and \Cyclus for each isotope. Positive difference indicates \Cyclus 
+        \gls{UDB} and \Cyclus for each isotope. Positive difference indicates \Cyclus 
         mass estimate is larger.}
         \label{fig:absolute}
 \end{figure*} 
 \FloatBarrier
 
 The 
-cumulative spent fuel isotopic mass difference between UDB and \Cyclus data for 
+cumulative spent fuel isotopic mass difference between \gls{UDB} and \Cyclus data for 
 the year 2000 (figure \ref{fig:absolute_diff_2000}) demonstrates the impact of 
 burnup on isotopic composition.  In figure 
 \ref{fig:burn_up_real}, at year 2000, the cumulative average U.S. nuclear 
-reactor burnup was very close to 33 GWDt/MTU. Therefore, the difference in 
+reactor burnup was very close to 33 GWD/MTU. Therefore, the difference in 
 burnup between the U.S. nuclear reactor burnup and \Cyclus data burnup was 
-around 20 GWDt/MTU for 51 GWDt/MTU burnup and 0 GWDt/MTU for 33 GWDt/MTU burnup 
+around 20 GWD/MTU for 51 GWD/MTU burnup and 0 GWD/MTU for 33 GWD/MTU burnup 
 (as seen in figure \ref{fig:burn_up_difference}). 
 
 As discussed by Wigeland et al \cite{wigeland_separations_2006}, $^{240}$Pu, 
@@ -249,25 +252,25 @@ and $^{137}$Cs are the most significant short term decay heat contributors
 
 
 In figure \ref{fig:absolute_diff_2000}, the \Cyclus simulation that uses the 33 
-GWDt/MTU burnup recipe has a small mass difference between UDB and \Cyclus data 
-for $^{240}$Pu and $^{241}$Am compared to 51 GWDt/MTU burnup. However, it has a 
+GWD/MTU burnup recipe has a small mass difference between \gls{UDB} and \Cyclus data 
+for $^{240}$Pu and $^{241}$Am compared to 51 GWD/MTU burnup. However, it has a 
 substantial difference for $^{239}$Pu. Figure 4 also shows small differences 
-between UDB and \Cyclus data for $^{238}$Pu, $^{244}$Cm, $^{90}$Sr and 
+between \gls{UDB} and \Cyclus data for $^{238}$Pu, $^{244}$Cm, $^{90}$Sr and 
 $^{137}$Cs. 
 
-The large mass difference between UDB and \Cyclus data (where UDB $^{239}$Pu 
+The large mass difference between \gls{UDB} and \Cyclus data (where \gls{UDB} $^{239}$Pu 
 mass is larger than \Cyclus $^{239}$Pu mass) for $^{239}$Pu in figures 
 \ref{fig:absolute_diff_2000}, \ref{fig:absolute_diff_all_51} and 
 \ref{fig:absolute_diff_all_33} can be attributed to conservative depletion 
-parameters used in the calculations for isotopic compositions in the UDB 
+parameters used in the calculations for isotopic compositions in the \gls{UDB} 
 database \cite{peterson_additional_2017}. These assumptions result in the 
 hardening of the neutron spectrum that results in increased $^{239}$Pu 
-production in the UDB data \cite{peterson_additional_2017}. 
+production in the \gls{UDB} data \cite{peterson_additional_2017}. 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \section{Conclusions}
 This work demonstrates that the spent fuel mass and isotopic composition 
-calculated by the \Cyclus simulation of the United States nuclear fuel cycle 
+calculated by the \Cyclus simulation of the \gls{US} nuclear fuel cycle 
 closely follow the results from real world metrics. This provides confidence 
 that \Cyclus can be used to produce accurate isotopic decay heat contributions and 
 simulate loading of a waste repository based on thermal constraints. 
@@ -277,16 +280,14 @@ recipes.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \section{Acknowledgments}
-This research is being performed using funding received from the DOE Office of 
+This research is being performed using funding received from the \gls{DOE} Office of 
 Nuclear Energy's Nuclear Energy University Program (Project 16-10512) 
 "Demand-Driven Cycamore Archetypes". The authors want to thank members of the 
-Advanced Reactors and Fuel Cycles research group (ARFC) at University of 
-Illinois at Urbana-Champaign, and Jin Whan Bae in particular, for valuable advice and 
-Gregory Westphal for proofreading. We also thank our colleagues from the 
-\Cyclus community, particularly those in the University of Wisconsin 
-Computational Nuclear Engineering Research Group (CNERG) and the University of 
-South Carolina Energy Research Group (ERGS) for their collaborative support 
-of the \Cyclus software.
+\gls{ARFC} group at the University of Illinois at Urbana-Champaign, 
+particularly Jin Whan Bae and Gregory Westphal. We also thank our colleagues 
+from the \Cyclus community, particularly those in the University of Wisconsin 
+\gls{CNERG} and the University of South Carolina Energy Research Group (ERGS) 
+for collaborative \Cyclus development.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \bibliographystyle{ans}

--- a/docs/chee-predicting-ans.tex
+++ b/docs/chee-predicting-ans.tex
@@ -285,8 +285,8 @@ Illinois at Urbana-Champaign, and Jin Whan Bae in particular, for valuable advic
 Gregory Westphal for proofreading. We also thank our colleagues from the 
 \Cyclus community, particularly those in the University of Wisconsin 
 Computational Nuclear Engineering Research Group (CNERG) and the University of 
-South Carolina Energy Research Group (ERGS) who provided collaborative support 
-in the development of the core software, \Cyclus, enabling this work. 
+South Carolina Energy Research Group (ERGS) for their collaborative support 
+of the \Cyclus software.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \bibliographystyle{ans}

--- a/docs/chee-predicting-ans.tex
+++ b/docs/chee-predicting-ans.tex
@@ -15,6 +15,8 @@ gchee2@illinois.edu
 \usepackage{xspace}
 \usepackage{tabularx}
 \usepackage{subcaption}
+\usepackage{enumitem}
+\usepackage{placeins}
 \newcommand{\SN}{S$_N$}
 \renewcommand{\vec}[1]{\bm{#1}} %vector is bold italic
 \newcommand{\vd}{\bm{\cdot}} % slightly bold vector dot
@@ -72,7 +74,6 @@ closely replicate reality.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \section{Methodology}
-\subsection{\textit{\Cyclus Simulation and Analysis}}
 A \Cyclus simulation of the United States nuclear fuel cycle was created using 
 published data of the 112 commerical nuclear reactors that have operated since 
 1967 in the United States. The reactor deployment data was obtained from the 
@@ -90,13 +91,12 @@ used in Python to render the data into an input file that is accepted by
 
 The assumptions made for this \Cyclus simulation include: 
 
-\begin{enumerate}
+\begin{enumerate}[topsep=0pt,itemsep=-1ex,partopsep=1ex,parsep=1ex]
 	\item Cycle time is assumed to be 18 months. 
 	\item Refueling time is assumed to be 1 month. 
 	\item There is isotopic decay. 
 \end{enumerate}
 
-\subsection{\textit{UDB Data Analysis}}
 The UDB database contains commercial SNF information from 1967 through 2013. 
 Data such as initial enrichment, burnup, mass of spent fuel and discharged 
 dates were collected from multiple sources \cite{peterson_additional_2017}. 
@@ -135,7 +135,7 @@ one month.
 \end{figure}
 
 The Nuclear Energy Institute (NEI) reported significant 
-variance in the refueling period for reactors in the United States. While average 
+variance in the refueling period for US reactors. While average 
 refuelling time in 1990 was 104 days, it decreased to an average 
 refuelling time of 35 days in 2017 \cite{iaea_current_nodate}.
 
@@ -207,19 +207,29 @@ $^{242}$Pu and $^{240}$Pu. They are similar for the isotopes on the left side
 of both figures. With an exception of $^{239}$Pu having a substantial larger 
 difference for 33 GWDt/MTU than 51 GWDt/MTU. 
 
-\begin{figure}[t] % replace 't' with 'b' to force it to be on the bottom
+\begin{figure*}[htb] % replace 't' with 'b' to force it to be on the bottom
 	\centering
-	\includegraphics[width=0.48\textwidth]{figures/absolute_diff_all_51}
-	\caption{The absolute difference between spent fuel mass from UDB data and \Cyclus data for each isotope for burnup of 51 GWDt/MTU (Positive difference means \Cyclus data is larger and negative difference means UDB data is larger).}
+        \begin{subfigure}{0.9\textwidth}
+        \includegraphics[height=0.30\textheight]{figures/absolute_diff_all_51}
+        \caption{51 GWD/MTU burnup.}
 	\label{fig:absolute_diff_all_51}
-\end{figure} 
-
-\begin{figure}[t] % replace 't' with 'b' to force it to be on the bottom
-	\centering
-	\includegraphics[width=0.48\textwidth]{figures/absolute_diff_all_33}
-	\caption{The absolute difference between spent fuel mass from UDB data and \Cyclus data for each isotope for burnup of 33 GWDt/MTU (Positive difference means \Cyclus data is larger and negative difference means UDB data is larger).}
+        \end{subfigure}
+        \begin{subfigure}{0.9\textwidth}
+        \includegraphics[height=0.30\textheight]{figures/absolute_diff_all_33}
+        \caption{33 GWD/MTU burnup.}
 	\label{fig:absolute_diff_all_33}
-\end{figure} 
+        \end{subfigure}
+        \begin{subfigure}{0.9\textwidth}
+        \includegraphics[height=0.35\textheight]{figures/absolute_diff_2000}
+        \caption{Both burnup states, year 2000 data.}
+	\label{fig:absolute_diff_2000}
+        \end{subfigure}
+        \caption{The absolute difference between spent fuel mass calculated by 
+        UDB and \Cyclus for each isotope. Positive difference indicates \Cyclus 
+        mass estimate is larger.}
+        \label{fig:absolute}
+\end{figure*} 
+\FloatBarrier
 
 The 
 cumulative spent fuel isotopic mass difference between UDB and \Cyclus data for 
@@ -237,12 +247,6 @@ contributors to each waste package. While, $^{238}$Pu, $^{244}$Cm, $^{90}$Sr
 and $^{137}$Cs are the most significant short term decay heat contributors 
 \cite{wigeland_separations_2006} to each waste package. 
 
-\begin{figure}[t] % replace 't' with 'b' to force it to be on the bottom
-	\centering
-	\includegraphics[width=0.48\textwidth]{figures/absolute_diff_2000}
-	\caption{The absolute difference between spent fuel mass from UDB data and \Cyclus data for each isotope at year 2000 for burnup of 33 GWd/MTU and 51 GWd/MTU (Positive difference means \Cyclus data is larger and negative difference means UDB data is larger).}
-	\label{fig:absolute_diff_2000}
-\end{figure} 
 
 In figure \ref{fig:absolute_diff_2000}, the \Cyclus simulation that uses the 33 
 GWDt/MTU burnup recipe has a small mass difference between UDB and \Cyclus data 
@@ -266,17 +270,10 @@ This work demonstrates that the spent fuel mass and isotopic composition
 calculated by the \Cyclus simulation of the United States nuclear fuel cycle 
 closely follow the results from real world metrics. This provides confidence 
 that \Cyclus can be used to produce accurate isotopic decay heat contributions and 
-simulate loading of a waste repository based on thermal constraints. However, 
-improvements can be made to more closely replicate reality.  
-
-Further work that would improve the simulation is to give the reactor agent the 
+simulate loading of a waste repository based on thermal constraints. 
+To more closely replicate reality, future work will give the reactor agent the 
 capability to accept varying cycle lengths, refueling durations and spent fuel 
-recipes. A \Cyclus simulation then can be made to replicate the historic U.S 
-nuclear fuel cycle even more closely by matching the cycle length, refueling 
-time and spent fuel recipes for specific reactors throughout their lifetimes. 
-This will give more accurate spent fuel mass and isotopic compositions which 
-will in turn make the \Cyclus simulations for loading of a waste repository 
-more accurate. 
+recipes.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \section{Acknowledgments}


### PR DESCRIPTION
- hard wraps lines to 80 chars
- makes grammar edits
- makes figures larger (the isotope labels were unreadable)
- makes conclusion more brief.
- fixes special characters in the bib by updating the erroneous zotero items and re-exporting the  .bib file.